### PR TITLE
Recovery mask

### DIFF
--- a/recovery/elliptics_recovery/dc_recovery.py
+++ b/recovery/elliptics_recovery/dc_recovery.py
@@ -99,7 +99,7 @@ class KeyRecover(object):
                      'The key will be recovered at groups with uncommitted replicas too.'
                      .format(self.key, incomplete_groups, same_groups))
 
-        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size, lhs.user_flags) == (rhs.timestamp, rhs.size, rhs.user_flags)
         same_infos = [info for info in self.key_infos if same_meta(info, same_infos[0])]
         self.key_flags = same_infos[0].flags
 
@@ -370,7 +370,7 @@ def iterate_key(filepath, groups):
 
             # if all key_infos has the same timestamp and size and there is no missed groups -
             # skip key, it is already up-to-date in all groups
-            same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+            same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size, lhs.user_flags) == (rhs.timestamp, rhs.size, rhs.user_flags)
             if same_meta(key_infos[0], key_infos[-1]) and not missed_groups:
                 continue
 

--- a/recovery/elliptics_recovery/dc_server_send.py
+++ b/recovery/elliptics_recovery/dc_server_send.py
@@ -235,7 +235,7 @@ class ServerSendRecovery(object):
         because less relevant replica (e.g. with older timestamp) should not be used for
         recovery due to temporary unavailability of relevant replica during recovery process.
         '''
-        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size, lhs.user_flags) == (rhs.timestamp, rhs.size, rhs.user_flags)
         num_failed_keys = 0
         for key in keys:
             key_infos = key_infos_map[str(key)]
@@ -343,7 +343,7 @@ class ServerSendRecovery(object):
         '''
         missed_groups = list(self.groups_set.difference([k.group_id for k in key_infos]))
 
-        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+        same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size, lhs.user_flags) == (rhs.timestamp, rhs.size, rhs.user_flags)
         diff_groups = [info.group_id for info in key_infos if not same_meta(info, key_infos[0])]
 
         missed_groups.extend(diff_groups)

--- a/recovery/elliptics_recovery/iterator.py
+++ b/recovery/elliptics_recovery/iterator.py
@@ -425,8 +425,11 @@ class MergeData(object):
         if cmp_res == 0:
             cmp_res = cmp(other.value.timestamp, self.value.timestamp)
 
-            if cmp_res == 0:
-                cmp_res = cmp(self.value.size, other.value.size)
+        if cmp_res == 0:
+            cmp_res = cmp(self.value.size, other.value.size)
+
+        if cmp_res == 0:
+            cmp_res = cmp(other.value.user_flags, self.value.user_flags)
 
         return cmp_res
 

--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -94,6 +94,7 @@ def main(options, args):
     ctx.custom_recover = options.custom_recover
     ctx.no_meta = options.no_meta and (options.timestamp is None)
     ctx.no_server_send = options.no_server_send
+    ctx.user_flags_set = frozenset(options.user_flags_set)
 
     try:
         ctx.trace_id = int(options.trace_id, 16)
@@ -414,4 +415,6 @@ def run(args=None):
                       help='Marks all recovery commands by trace_id at both recovery and server logs. This option accepts hex strings. [default: %default]')
     parser.add_option('-U', '--no-server-send', action="store", dest="no_server_send", default=False,
                       help='Do not use server-send for recovery. Disabling recovery via server-send useful if there is no network connection between groups')
+    parser.add_option('--user-flags', action='append', dest='user_flags_set', default=[],
+                      help='Recover key if at least one replica has user_flags from specified user_flags_set')
     return main(*parser.parse_args(args))

--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -295,7 +295,7 @@ def fill_buckets(ctx, results):
 
     for filename, _, _ in results:
         for key, key_infos in load_key_data(filename):
-            same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size) == (rhs.timestamp, rhs.size)
+            same_meta = lambda lhs, rhs: (lhs.timestamp, lhs.size, lhs.user_flags) == (rhs.timestamp, rhs.size, rhs.user_flags)
             same_info_groups = [info.group_id for info in key_infos if same_meta(info, key_infos[0])]
 
             for group in ctx.bucket_order:

--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -113,6 +113,9 @@ def skip_key_data(ctx, key_data):
     Checks that all groups are presented in key_data and
     all key_datas have equal timestamp and user_flags
     '''
+    if ctx.user_flags_set and all(info.user_flags not in ctx.user_flags_set for info in key_data[1]):
+        return True
+
     committed = lambda info: not (info.flags & elliptics.record_flags.uncommitted)
     count = sum(map(committed, key_data[1]))
     if count < len(ctx.groups):


### PR DESCRIPTION
recovery: added --user_flags option: recover key if at least one replica has user_flags from specified user_flags_set

If user_flags from all key's replicas are not in user_flags_set, then this key will be skipped during recovery. If user_flags_set is not specified (by default), then recovery will not skip any keys.