### PR TITLE
Hide sph in cocaine invocation headers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,9 +23,9 @@ Build-Depends: cdbs,
  handystats (>= 1.11.0),
  blackhole-dev (>= 1.0.0-0alpha10),
  blackhole-migration-dev (>= 1.0.0-0alpha10),
- libcocaine-dev (>= 0.12.8.6),
- libcocaine-plugin-node-dev (>= 0.12.8.18),
- libcocaine-framework-native-dev (>= 0.12.8-2),
+ libcocaine-dev (>= 0.12.8.11),
+ libcocaine-plugin-node-dev (>= 0.12.8.21),
+ libcocaine-framework-native-dev (>= 0.12.8-6),
 Standards-Version: 3.8.0
 Homepage: http://www.ioremap.net/projects/elliptics
 XS-Python-Version: >= 2.6
@@ -36,8 +36,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  eblob (>= 0.23.11),
  elliptics-client (= ${Source-Version}),
  handystats (>= 1.11.0),
- libcocaine-core3 (>= 0.12.8.6),
- libcocaine-plugin-node3 (>= 0.12.8.18),
+ libcocaine-core3 (>= 0.12.8.11),
+ libcocaine-plugin-node3 (>= 0.12.8.21),
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
 Description: Distributed hash table storage
@@ -60,7 +60,7 @@ Description: Distributed hash table storage (cocaine plugin)
 
 Package: libcocaine-plugin-elliptics-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-framework-native-dev (>= 0.12.8-2)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libcocaine-framework-native-dev (>= 0.12.8-6)
 Description: Distributed hash table storage (cocaine plugin includes)
  Elliptics network is a fault tolerant distributed hash table object storage.
 

--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -58,6 +58,14 @@
 
 namespace ioremap { namespace elliptics {
 
+/// Elliptics to cocaine logger adapter.
+///
+/// Current elliptics logger is actually a wrapper over on blackhole v0.2 logger,
+/// Current cocaine logger is generalized logger interface from blackhole v1.0 (which was rewritten from scratch).
+///
+/// This logger_adapter wraps v0.2 logger into v1.0 logger interface.
+///
+
 inline
 blackhole::v1::severity_t convert_severity(dnet_log_level level)
 {
@@ -90,14 +98,6 @@ dnet_log_level convert_severity(blackhole::v1::severity_t severity)
 			return DNET_LOG_ERROR;
 	}
 }
-
-/// Elliptics to cocaine logger adapter.
-///
-/// Current elliptics logger is actually a wrapper over on blackhole v0.2 logger,
-/// Current cocaine logger is generalized logger interface from blackhole v1.0 (which was rewritten from scratch).
-///
-/// This logger_adapter wraps v0.2 logger into v1.0 logger interface.
-///
 
 /// Scope manager.
 //
@@ -408,6 +408,10 @@ public:
 	}
 };
 
+
+//
+// Main class which implements `exec` command processing and glues elliptics with cocaine.
+//
 class srw
 {
 	struct exec_session
@@ -533,7 +537,6 @@ class srw
 		}
 		return std::make_tuple(s, std::string());
 	};
-
 
 public:
 	srw(struct dnet_node *n, const std::string &config)

--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -416,6 +416,19 @@ class srw
 		std::shared_ptr<cocaine::api::stream_t> back_stream_;
 	};
 
+	struct headers
+	{
+		struct sph
+		{
+			static
+			constexpr
+			cocaine::hpack::header::data_t
+	        name() {
+	            return cocaine::hpack::header::create_data("sph");
+	        }
+		};
+	};
+
 	struct dnet_node   *m_node;
 
 	// main cocaine core object -- context
@@ -800,14 +813,17 @@ public:
 					return exec_context_data::copy(other, other.event(), data_pointer());
 				};
 
+				// clean copy drops payload
+				auto exec_clean_copy = clean_copy(exec);
+
 				auto session = std::make_shared<client_session>(
-					st, cmd, app, signature, clean_copy(exec)
+					st, cmd, app, signature, exec_clean_copy
 				);
 				dnet_log(m_node, DNET_LOG_DEBUG, "%s: srw: exec_context original, size: total %ld, event %ld(%d), payload %ld", signature.c_str(),
 					exec.native_data().size(), exec.event().size(), exec.native_data().data<sph>()->event_size, exec.data().size()
 				);
 				dnet_log(m_node, DNET_LOG_DEBUG, "%s: srw: exec_context session copy, size: total %ld, event %ld(%d), payload %ld", signature.c_str(),
-					session->exec_copy_.native_data().size(), session->exec_copy_.event().size(), session->exec_copy_.native_data().data<sph>()->event_size, session->exec_copy_.data().size()
+					exec_clean_copy.native_data().size(), exec_clean_copy.event().size(), exec_clean_copy.native_data().data<sph>()->event_size, exec_clean_copy.data().size()
 				);
 
 				// optional tag to stick processing to a certain worker
@@ -837,26 +853,40 @@ public:
 				}
 
 				try {
+					namespace h = cocaine::hpack;
+
+					const auto headers = h::header_storage_t({
+						h::header_t::create<headers::sph>(h::header::create_data(
+							exec_clean_copy.native_data().data<char>(), exec_clean_copy.native_data().size()
+						))
+					});
+
+					{
+						dnet_log(m_node, DNET_LOG_DEBUG, "%s: header count %lu", __func__, headers.get_headers().size());
+						for (const auto &i : headers.get_headers()) {
+							const std::string name(i.get_name().blob, i.get_name().size);
+							const std::string value(i.get_value().blob, i.get_value().size);
+							dnet_log(m_node, DNET_LOG_DEBUG, "%s:   name: %s, value: %x", __func__, name.c_str(), *(int*)value.data());
+						}
+					}
+
 					//FIXME: get rid of this copy from data_pointer to a std::string
-					const std::string chunk = exec.native_data().to_string();
+					const std::string chunk = exec.data().to_string();
 
 					dnet_log(m_node, DNET_LOG_DEBUG, "%s: srw: enqueueing, tag '%s', event '%s', chunk size %lu", signature.c_str(), tag.c_str(), event.c_str(), chunk.size());
 
 					auto send_stream = app_overseer->enqueue(
 						back_stream,
-						cocaine::service::node::app::event_t(
-							event,
-							cocaine::hpack::header_storage_t()
-						),
+						cocaine::service::node::app::event_t(event, std::move(headers)),
 						//TODO: there is some problem with tags in cocaine 12.7, disable them for now
 						// cocaine::service::node::slave::id_t(tag)
 						boost::none
 					);
 
-					send_stream->write(cocaine::hpack::header_storage_t(), chunk);
+					send_stream->write(h::header_storage_t(), chunk);
 
 					// Request stream should be closed after all data was sent to prevent resource leakage.
-					send_stream->close(cocaine::hpack::header_storage_t());
+					send_stream->close(h::header_storage_t());
 
 					dnet_log(m_node, DNET_LOG_INFO, "%s: srw: enqueued, src_key %d, job %d, payload size %zd, block %d",
 						signature.c_str(),

--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -305,6 +305,8 @@ public:
 	virtual auto error(cocaine::hpack::header_storage_t, const std::error_code& code, const std::string& reason) -> void {
 		SRW_LOG(*logger_, DNET_LOG_ERROR, app_, "%s: stream: got error from app, %s: (%d) %s", signature_, reason, code.value(), code.message());
 		if (auto client = client_.lock()) {
+			//TODO: translate cocaine errors into elliptics error code space (errno),
+			// for some errors, e.g. for "unknown/unhandled event" error
 			client->finish(code.value());
 
 			// notify that we are done and this cocaine session closed

--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -978,6 +978,10 @@ int dnet_cmd_exec(struct dnet_net_state *st, struct dnet_cmd *cmd, const void *p
 	try {
 		return srw->process(st, cmd, payload);
 
+	} catch(const std::exception &e) {
+		dnet_log(n, DNET_LOG_ERROR, "srw: processing failed: %s", e.what());
+		return -EINVAL;
+
 	} catch (...) {
 		dnet_log(n, DNET_LOG_ERROR, "srw: processing failed by unknown reason");
 		return -EINVAL;

--- a/tests/cocaine.conf
+++ b/tests/cocaine.conf
@@ -71,6 +71,6 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "debug"
     }
 }

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -145,9 +145,7 @@ static nodes_data::ptr configure_test_setup_from_args(int argc, char *argv[])
 }
 
 ///
-/// Checks worker response via cocaine response stream.
-/// From original client's point of view there should be no difference.
-/// Original client is able to receive reply.
+/// Checks retrieving info about application (via elliptics channel).
 ///
 static void test_info(session &client, const std::string &app_name)
 {
@@ -162,6 +160,49 @@ static void test_info(session &client, const std::string &app_name)
 	BOOST_REQUIRE_GT(result.size(), 0);
 	BOOST_REQUIRE_EQUAL(result[0], '{');
 	BOOST_REQUIRE_EQUAL(result[result.size() - 1], '}');
+}
+
+///
+/// Checks response on event dispatching errors.
+///
+static void test_dispatch_errors(session &client, const std::string &app_name)
+{
+	// -2 on system `info` event to unknown app
+	{
+		key key(std::string(__func__) + "info");
+		key.transform(client);
+		dnet_id id = key.id();
+
+		auto async = client.exec(&id, "unknown-app@info", "");
+		async.wait();
+		BOOST_REQUIRE_EQUAL(async.error().code(), -2);
+	}
+
+	// -2 on any event to unknown app
+	{
+		key key(std::string(__func__) + "any-event");
+		key.transform(client);
+		dnet_id id = key.id();
+
+		auto async = client.exec(&id, "unknown-app@any-event", "");
+		async.wait();
+		BOOST_REQUIRE_EQUAL(async.error().code(), -2);
+	}
+
+	// -2 on unknown event to known app
+	//FIXME: right now error code is 1 because srw passes code received from the worker
+	// and this code is too uncertain now (also across different frameworks) to rely on it
+	// and to make a permanent translation into -2.
+	// Fix when cocaine will stabilize it.
+	{
+		key key(std::string(__func__) + "unknown-event");
+		key.transform(client);
+		dnet_id id = key.id();
+
+		auto async = client.exec(&id, app_name + "@unknown-event", "");
+		async.wait();
+		BOOST_REQUIRE_EQUAL(async.error().code(), 1);
+	}
 }
 
 ///
@@ -483,6 +524,8 @@ bool register_tests(const nodes_data *setup)
 	ELLIPTICS_TEST_CASE(init_application_impl, use_session(n, { 1 }), app, setup);
 
 	ELLIPTICS_TEST_CASE(test_info, use_session(n, { 1 }), app);
+
+	ELLIPTICS_TEST_CASE(test_dispatch_errors, use_session(n, { 1 }), app);
 
 	/// various ways to send a reply to an `exec` command
 	ELLIPTICS_TEST_CASE(test_echo_via_elliptics, use_session(n, { 1 }), app, "some-data");

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -521,6 +521,7 @@ bool register_tests(const nodes_data *setup)
 	for (const auto &i : setup->nodes) {
 		ELLIPTICS_TEST_CASE(start_application, i.locator_port(), app);
 	}
+
 	ELLIPTICS_TEST_CASE(init_application_impl, use_session(n, { 1 }), app, setup);
 
 	ELLIPTICS_TEST_CASE(test_info, use_session(n, { 1 }), app);
@@ -552,10 +553,10 @@ bool register_tests(const nodes_data *setup)
 
 	/// continuous load handles properly
 	//TODO: micro stress test similar to timeout test:
-	// - send wast stream of commands, big enough to affect concurrency rate
+	// - send vast stream of commands, big enough to affect concurrency rate
 	//   and number of spawned workers;
 	// - wait for completion;
-	// - check app info if load stat return to zero
+	// - check app info if load stat returned to zero
 
 	/// localnode service
 	// * data structures


### PR DESCRIPTION
Before this change srw was sending sph to the cocaine worker explicitly, as a prefix to the actual user payload, so cocaine worker was required to manually separate its input into sph and payload.

Not only it meant an extra work for authors of cocaine apps, but also it made apps dependent on the execution context: same app could not run without a change under both standalone cociane runtime or srw. (While it was possible to guess about presence of the sph prefix, it couldn't be done reliably).

Here comes handy the new feature of cocaine-v12 -- headers. And ability to use them to pass supplemental data separate but along with user data.

This change passes sph through cocaine invocation headers. So workers for srw (which have no use for sph) can be exactly the same as for standalone cocaine.

For workers which do require sph -- header name "sph".
And srw_test_app.cpp shows example on how to get sph from invocation headers on worker's side.