### PR TITLE
srw: link with new cocaine-io-util shared lib

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+elliptics (2.26.10.3-6~srw5) unstable; urgency=medium
+
+  * srw: adopt changes from cocaine - link with cocaine-io-util
+
+ -- Anton Matveenko <antmat@yandex-team.ru>  Wed, 18 May 2016 18:36:51 +0300
+
 elliptics (2.26.10.3-6~srw4) unstable; urgency=medium
 
   * srw: add test for dispatch errors (unknown app, unknown event)

--- a/srw/CMakeLists.txt
+++ b/srw/CMakeLists.txt
@@ -27,5 +27,6 @@ target_link_libraries(elliptics_srw
     ${COCAINE_NODE_SERVICE_LIBRARIES}
 
     #FIXME: should add it properly
+    cocaine-io-util
     blackhole
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,6 +249,7 @@ if(WITH_COCAINE)
         ${Boost_LIBRARIES}
         ${CocaineNative_LIBRARIES}
         #FIXME: should add it properly
+        cocaine-io-util
         blackhole
     )
 


### PR DESCRIPTION
Cocaine now provides common functionality in separate library. Elliptics SRW library and tests should link with it