### PR TITLE
Move blackhole v0.2 to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "foreign/cmp"]
 	path = foreign/cmp
 	url = git://github.com/camgunz/cmp.git
+[submodule "foreign/blackhole"]
+	path = foreign/blackhole
+	url = https://github.com/3Hren/blackhole.git
+	branch = v0.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,7 @@ include(CheckProcStats)
 include(CreateStdint)
 include(FixRpath)
 
-find_path(BLACKHOLE_INCLUDE_DIRS NAMES "blackhole/attribute.hpp" PATH_SUFFIXES)
-if (NOT BLACKHOLE_INCLUDE_DIRS)
-	message(FATAL_ERROR "Blackhole development files have not been found")
-endif()
-include_directories(${BLACKHOLE_INCLUDE_DIRS})
-
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/foreign/blackhole/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/monitor)

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Build-Depends:	cdbs,
 		cmake (>= 2.6),
 		debhelper (>= 7.0.50~),
 		eblob (>= 0.23.11),
-		blackhole-dev (= 0.2.4-1),
 		libboost-dev,
 		libboost-iostreams-dev,
 		libboost-program-options-dev,
@@ -66,7 +65,7 @@ Description: Distributed hash table storage (debug files)
 
 Package: elliptics-dev
 Architecture: any
-Depends: elliptics-client (= ${Source-Version}), blackhole-dev (= 0.2.4-1)
+Depends: elliptics-client (= ${Source-Version})
 Description: Distributed hash table storage (includes)
  Elliptics network is a fault tolerant distributed hash table object storage.
 

--- a/include/elliptics/logger.hpp
+++ b/include/elliptics/logger.hpp
@@ -15,7 +15,13 @@
 
 #include <blackhole/log.hpp>
 #include <blackhole/logger/wrapper.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+// Drop annoying warning "unused parameter ‘end’"
+// at blackhole-v0.2/src/blackhole/detail/datetime.hpp:420.
+// Should go away when elliptics will migrate to blackhole v1.0
 #include <blackhole/formatter/map/value.hpp>
+#pragma GCC diagnostic pop
 #include <blackhole/defaults/severity.hpp>
 
 #ifdef BOOST_BIND_NO_PLACEHOLDERS_SET_BY_ELLIPTICS


### PR DESCRIPTION
In preparation to coming migration to blackhole v1.0.
Elliptics packages now will not have dependency on blackhole v0.2.
Clients using elliptics client will be required to add blackhole as submodule
in their own source tree by themselves.