### PR TITLE
python: return None in read/lookup result entry's property on error

### DIFF
--- a/bindings/python/result_entry.cpp
+++ b/bindings/python/result_entry.cpp
@@ -303,28 +303,52 @@ std::string callback_result_get_raw_data(const newapi::callback_result_entry &re
 	return result.raw_data().to_string();
 }
 
-std::string lookup_result_get_path(const newapi::lookup_result_entry &result) {
-	return result.path();
+bp::object lookup_result_get_path(const newapi::lookup_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.path());
 }
 
-dnet_record_info lookup_result_get_record_info(const newapi::lookup_result_entry &result) {
-	return result.record_info();
+bp::object lookup_result_get_record_info(const newapi::lookup_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.record_info());
 }
 
-dnet_record_info read_result_get_record_info(const newapi::read_result_entry &result) {
-	return result.record_info();
+bp::object read_result_get_record_info(const newapi::read_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.record_info());
 }
 
-dnet_io_info read_result_get_io_info(const newapi::read_result_entry &result) {
-	return result.io_info();
+bp::object read_result_get_io_info(const newapi::read_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.io_info());
 }
 
-std::string read_result_get_json(const newapi::read_result_entry &result) {
-	return result.json().to_string();
+bp::object read_result_get_json(const newapi::read_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.json().to_string());
 }
 
-std::string read_result_get_data(const newapi::read_result_entry &result) {
-	return result.data().to_string();
+bp::object read_result_get_data(const newapi::read_result_entry &result) {
+	if (result.status()) {
+		return bp::object();
+	}
+
+	return bp::object(result.data().to_string());
 }
 
 uint64_t iterator_result_get_iterator_id(const newapi::iterator_result_entry &result) {
@@ -394,7 +418,7 @@ void init_result_entry() {
 
 	bp::class_<iterator_result_entry, bp::bases<callback_result_entry> >("IteratorResultEntry")
 		.add_property("id", &iterator_result_entry::id,
-		              "Iterator integer ID. Which can be used for pausing, continuing and cancelling iterator")
+		              "Iterator integer ID. Which can be used for pausing, continuing and canceling iterator")
 		.add_property("response", iterator_result_response,
 		              "elliptics.IteratorResultResponse which provides meta information about iterated key")
 		.add_property("response_data", iterator_result_response_data,

--- a/tests/pytests/test_newapi.py
+++ b/tests/pytests/test_newapi.py
@@ -1,0 +1,64 @@
+import elliptics
+
+import json
+import errno
+
+from conftest import make_trace_id
+
+
+def test_lookup_read_nonexistent_key(server, simple_node):
+    """Try to lookup and read a non-existent key and validate fields of results."""
+    session = elliptics.newapi.Session(simple_node)
+    session.trace_id = make_trace_id('test_lookup_read_nonexistent_key')
+    session.exceptions_policy = elliptics.exceptions_policy.no_exceptions
+    session.groups = session.routes.groups()
+
+    key = 'test_lookup_read_nonexistent_key'
+    for result in session.lookup(key):
+        assert result.status == -errno.ENOENT
+        assert result.record_info is None
+        assert result.path is None
+
+    for result in session.read(key):
+        assert result.status == -errno.ENOENT
+        assert result.record_info is None
+        assert result.io_info is None
+        assert result.json is None
+        assert result.data is None
+
+def test_lookup_read_existent_key(server, simple_node):
+    """Write a key, lookup and read it and validate fields of results."""
+    session = elliptics.newapi.Session(simple_node)
+    session.trace_id = make_trace_id('test_lookup_read_existent_key')
+    session.groups = session.routes.groups()
+
+    key = 'test_lookup_read_existent_key'
+    json_string = json.dumps({'some': 'field'})
+    data = 'some data'
+
+    i = 0
+    for i, result in enumerate(session.write(key, json_string, len(json_string), data, len(data)),
+                               start=1):
+        assert result.status == 0
+        assert result.record_info.json_size == len(json_string)
+        assert result.record_info.json_capacity == len(json_string)
+        assert result.record_info.data_size == len(data)
+    assert i == len(session.groups)
+
+    i = 0
+    for i, result in enumerate(session.lookup(key), start=1):
+        assert result.status == 0
+        assert result.record_info.json_size == len(json_string)
+        assert result.record_info.json_capacity == len(json_string)
+        assert result.record_info.data_size == len(data)
+    assert i == 1
+
+    i = 0
+    for i, result in enumerate(session.read(key, 0, 0), start=1):
+        assert result.status == 0
+        assert result.record_info.json_size == len(json_string)
+        assert result.record_info.json_capacity == len(json_string)
+        assert result.record_info.data_size == len(data)
+        assert result.json == json_string
+        assert result.data == data
+    assert i == 1


### PR DESCRIPTION
Return `None` in:
 * `newapi.LookupResultEntry.path`
 * `newapi.LookupResultEntry.record_info`
 * `newapi.ReadResultEntry.record_info`
 * `newapi.ReadResultEntry.io_info`
 * `newapi.ReadResultEntry.json`
 * `newapi.ReadResultEntry.data`

for an entry with error in status.

Add tests for it.