### PR TITLE
Check RO status of backend on WRITE_NEW

### DIFF
--- a/include/elliptics/async_result.hpp
+++ b/include/elliptics/async_result.hpp
@@ -31,11 +31,11 @@ class session;
 /*!
  * async_result is a template class that provides result of request processing.
  *
- * It provides both synchronious and asynchronious ways of usage.
+ * It provides both synchronous and asynchronous ways of usage.
  *
- * Synchronious is provided by wait/get methods and iterator API.
+ * Synchronous is provided by wait/get methods and iterator API.
  *
- * Asynchronious is provided by connect methods.
+ * Asynchronous is provided by connect methods.
  */
 template <typename T>
 class async_result
@@ -132,7 +132,7 @@ class async_result
 		  * Returnes expected number of received positive final replies from server.
 		  *
 		  * This number is used afterwards in session::checker to determine if
-		  * operation was successfull.
+		  * operation was successful.
 		  */
 		 size_t total() const;
 

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -1610,6 +1610,11 @@ static int dnet_process_cmd_with_backend_raw(struct dnet_backend_io *backend, st
 				}
 			}
 
+			if ((n->ro || backend->read_only) && (cmd->cmd == DNET_CMD_WRITE_NEW)) {
+				err = -EROFS;
+				break;
+			}
+
 			/* Remove DNET_FLAGS_NEED_ACK flags for READ/WRITE/LOOKUP commands
 			   to eliminate double reply packets
 			   (the first one with dnet_file_info structure or data has been read,


### PR DESCRIPTION
Added test which turns backend into RO and checks that write into this backend is failed with -EROFS error.