### PR TITLE
Add json_timestamp to elliptics.newapi.Session

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -809,6 +809,40 @@ public:
 		return new elliptics_session(session::clone());
 	}
 
+	void set_timestamp(const bp::api::object &time_obj) {
+		if (time_obj.ptr() == Py_None) {
+			newapi::session{*this}.reset_timestamp();
+		} else {
+			elliptics_time &ts = bp::extract<elliptics_time&>(time_obj);
+			newapi::session{*this}.set_timestamp(ts.m_time);
+		}
+	}
+
+	bp::object get_timestamp() const {
+		auto ts = newapi::session{*this}.get_timestamp();
+		if (dnet_time_is_empty(&ts)) {
+			return bp::object();
+		}
+		return bp::object(elliptics_time(ts));
+	}
+
+	void set_json_timestamp(const bp::api::object &time_obj) {
+		if (time_obj.ptr() == Py_None) {
+			newapi::session{*this}.reset_json_timestamp();
+		} else {
+			elliptics_time &ts = bp::extract<elliptics_time&>(time_obj);
+			newapi::session{*this}.set_json_timestamp(ts.m_time);
+		}
+	}
+
+	bp::object get_json_timestamp() const {
+		auto ts = newapi::session{*this}.get_json_timestamp();
+		if (dnet_time_is_empty(&ts)) {
+			return bp::object();
+		}
+		return bp::object(elliptics_time(ts));
+	}
+
 	python_lookup_result lookup(const bp::api::object &id) {
 		return create_result(
 			newapi::session{*this}.lookup(transform(id).id())
@@ -2069,6 +2103,20 @@ void init_elliptics_session() {
 		                 "__init__(node)\n"
 		                 "    Initializes session by the node\n\n"
 		                 "    session = elliptics.newapi.Session(node)"))
+
+		.add_property("timestamp",
+		              &newapi::elliptics_session::get_timestamp,
+		              &newapi::elliptics_session::set_timestamp,
+		    "Timestamp which would be applied to\n"
+		    "all operations executed by the session\n\n"
+		    "session.timestamp = elliptics.Time.now()")
+
+		.add_property("json_timestamp",
+		              &newapi::elliptics_session::get_json_timestamp,
+		              &newapi::elliptics_session::set_json_timestamp,
+		    "Json timestamp which would be applied to\n"
+		    "all operations executed by the session\n\n"
+		    "session.json_timestamp = elliptics.Time.now()")
 
 		.def("clone", &newapi::elliptics_session::clone,
 		     bp::return_value_policy<bp::manage_new_object>(),

--- a/tests/pytests/test_newapi.py
+++ b/tests/pytests/test_newapi.py
@@ -8,7 +8,8 @@ import pytest
 from conftest import make_trace_id
 
 
-def test_lookup_read_nonexistent_key(server, simple_node):
+@pytest.mark.usefixtures('server')
+def test_lookup_read_nonexistent_key(simple_node):
     """Try to lookup and read a non-existent key and validate fields of results."""
     session = elliptics.newapi.Session(simple_node)
     session.trace_id = make_trace_id('test_lookup_read_nonexistent_key')
@@ -28,7 +29,9 @@ def test_lookup_read_nonexistent_key(server, simple_node):
         assert result.json is None
         assert result.data is None
 
-def test_lookup_read_existent_key(server, simple_node):
+
+@pytest.mark.usefixtures('server')
+def test_lookup_read_existent_key(simple_node):
     """Write a key, lookup and read it and validate fields of results."""
     session = elliptics.newapi.Session(simple_node)
     session.trace_id = make_trace_id('test_lookup_read_existent_key')
@@ -66,7 +69,8 @@ def test_lookup_read_existent_key(server, simple_node):
     assert i == 1
 
 
-def test_use_session_clone(server, simple_node):
+@pytest.mark.usefixtures('server')
+def test_use_session_clone(simple_node):
     """Create session, clone and write a key by clone."""
     session = elliptics.newapi.Session(simple_node)
     session.trace_id = make_trace_id('test_use_session_after_clone')

--- a/tests/pytests/test_newapi.py
+++ b/tests/pytests/test_newapi.py
@@ -3,6 +3,8 @@ import elliptics
 import json
 import errno
 
+import pytest
+
 from conftest import make_trace_id
 
 
@@ -79,3 +81,50 @@ def test_use_session_clone(server, simple_node):
     clone.read_json(key).wait()
     clone.read_data(key).wait()
     clone.remove(key)
+
+
+@pytest.mark.usefixtures('server')
+def test_session_timestamps(simple_node):
+    """Test session.timestamp and session.json_timestamp."""
+    session = elliptics.newapi.Session(simple_node)
+    session.trace_id = make_trace_id('test_lookup_read_existent_key')
+    session.groups = session.routes.groups()
+
+    key = 'test_lookup_read_existent_key'
+    json_string = json.dumps({'some': 'field'})
+    data = 'some data'
+
+    data_ts = elliptics.Time.now()
+    json_ts = elliptics.Time.now()
+    assert json_ts > data_ts
+
+    assert session.timestamp is None
+    assert session.json_timestamp is None
+    # write and check timestamps from result
+    result = session.write(key, json_string, len(json_string), data, len(data)).get()[0]
+    assert elliptics.Time.now() > result.record_info.data_timestamp > data_ts
+    assert elliptics.Time.now() > result.record_info.json_timestamp > data_ts
+
+    session.timestamp = data_ts
+    assert session.timestamp == data_ts
+    assert session.json_timestamp is None
+    # write and check timestamps from result
+    result = session.write(key, json_string, len(json_string), data, len(data)).get()[0]
+    assert result.record_info.data_timestamp == data_ts
+    assert result.record_info.json_timestamp == data_ts
+
+    session.json_timestamp = json_ts
+    assert session.timestamp == data_ts
+    assert session.json_timestamp == json_ts
+    # write and check timestamps from result
+    result = session.write(key, json_string, len(json_string), data, len(data)).get()[0]
+    assert result.record_info.data_timestamp == data_ts
+    assert result.record_info.json_timestamp == json_ts
+
+    session.timestamp = None
+    assert session.timestamp is None
+    assert session.json_timestamp == json_ts
+    # write and check timestamps from result
+    result = session.write(key, json_string, len(json_string), data, len(data)).get()[0]
+    assert elliptics.Time.now() > result.record_info.data_timestamp > json_ts
+    assert result.record_info.json_timestamp == json_ts


### PR DESCRIPTION
Updated behaviour of `newapi.Session.timestamp` and `newapi.Session.json_timestamp`: now if they aren't specified or are reset they will be None.