### PR TITLE
Use libkora-util

### DIFF
--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -34,15 +34,15 @@
 
 namespace ioremap { namespace cache {
 
-std::unique_ptr<cache_config> cache_config::parse(const elliptics::config::config &cache)
+std::unique_ptr<cache_config> cache_config::parse(const kora::config_t &cache)
 {
 	auto size = cache.at("size");
-	if (size.as<size_t>() == 0) {
+	if (size.to<size_t>() == 0) {
 		throw elliptics::config::config_error(size.path() + " must be non-zero");
 	}
 
 	cache_config config;
-	config.size = size.as<size_t>();
+	config.size = size.to<size_t>();
 	config.count = cache.at<size_t>("shards", DNET_DEFAULT_CACHES_NUMBER);
 	config.sync_timeout = cache.at<unsigned>("sync_timeout", DNET_DEFAULT_CACHE_SYNC_TIMEOUT_SEC);
 	config.pages_proportions = cache.at("pages_proportions", std::vector<size_t>(DNET_DEFAULT_CACHE_PAGES_NUMBER, 1));

--- a/debian/control
+++ b/debian/control
@@ -23,14 +23,21 @@ Build-Depends:	cdbs,
 		python-pip,
 		python-virtualenv,
 		msgpack-python | python-msgpack,
-		handystats (>= 1.10.2)
+		handystats (>= 1.10.2),
+		libkora-util-dev (= 1.1.0-rc1)
 Standards-Version: 3.8.0
 Homepage: http://www.ioremap.net/projects/elliptics
 XS-Python-Version: >= 2.6
 
 Package: elliptics
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, eblob (>= 0.23.11), elliptics-client (= ${Source-Version}), libcocaine-core2, handystats (>= 1.10.0)
+Depends:	${shlibs:Depends},
+		${misc:Depends},
+		eblob (>= 0.23.11),
+		elliptics-client (= ${Source-Version}),
+		libcocaine-core2,
+		handystats (>= 1.10.0),
+		libkora-util1 (= 1.1.0-rc1)
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
 Description: Distributed hash table storage

--- a/example/config.hpp
+++ b/example/config.hpp
@@ -2,7 +2,8 @@
 #define CONFIG_HPP
 
 #include <elliptics/error.hpp>
-#include <blackhole/dynamic.hpp>
+#include <kora/dynamic.hpp>
+#include <kora/config.hpp>
 #include <blackhole/attribute.hpp>
 
 #include <elliptics/session.hpp>
@@ -66,281 +67,6 @@ private:
 	std::string m_message;
 };
 
-
-namespace detail
-{
-
-using blackhole::dynamic_t;
-
-enum {
-	boolean_type = 1,
-	integral_type = 2,
-	floating_point_type = 4,
-	string_type = 8,
-	vector_type = 16
-};
-
-template <typename T, int specific>
-struct config_value_caster_specific_helper;
-
-template <typename T>
-struct is_vector : public std::false_type { };
-
-template <typename T>
-struct is_vector<std::vector<T>> : public std::true_type { };
-
-
-template <typename T>
-struct config_value_caster_helper
-{
-	enum {
-		boolean = std::is_same<T, bool>::value ? boolean_type : 0,
-		integral = std::is_integral<T>::value && !boolean ? integral_type : 0,
-		floating_point = std::is_floating_point<T>::value ? floating_point_type : 0,
-		string = std::is_same<T, std::string>::value ? string_type : 0,
-		vector = is_vector<T>::value ? vector_type : 0,
-		type = integral | floating_point | string | boolean | vector
-	};
-
-	static_assert(integral || floating_point || string || boolean || vector, "Unsupported type");
-	static_assert((type == integral) || (type == floating_point) || (type == string) || (type == boolean) || (type == vector), "Internal type check error");
-
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		return config_value_caster_specific_helper<T, type>::cast(path, value);
-	}
-};
-
-template <typename T>
-struct config_value_caster : public config_value_caster_helper<typename std::remove_all_extents<T>::type>
-{
-};
-
-template <typename T>
-struct config_value_caster_specific_helper<T, boolean_type>
-{
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		if (!value.is<dynamic_t::bool_t>())
-			throw config_error() << path << " must be a bool";
-
-		return value.to<dynamic_t::bool_t>();
-	}
-};
-
-template <typename T>
-struct config_value_caster_specific_helper<T, integral_type>
-{
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		try {
-			// dynamic_t has it's own built-in range check support
-			// which throws precision_loss exception in case of error
-			// so it's safe just to call dynamic_t::to here
-			return value.to<T>();
-		} catch (blackhole::dynamic::precision_loss &) {
-			throw config_error() << path << " must be an integer between "
-				<< std::numeric_limits<T>::min() << " and " << std::numeric_limits<T>::max();
-		}
-	}
-};
-
-template <typename T>
-struct config_value_caster_specific_helper<T, floating_point_type>
-{
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		if (!value.is<dynamic_t::double_t>())
-			throw config_error() << path << " must be a floating point number";
-
-		return value.to<dynamic_t::double_t>();
-	}
-};
-
-template <typename T>
-struct config_value_caster_specific_helper<T, string_type>
-{
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		if (!value.is<dynamic_t::string_t>())
-			throw config_error() << path << " must be a string";
-
-		return value.to<dynamic_t::string_t>();
-	}
-};
-
-template <typename T>
-struct config_value_caster_specific_helper<T, vector_type>
-{
-	static T cast(const std::string &path, const dynamic_t &value)
-	{
-		typedef config_value_caster<typename T::value_type> caster;
-
-		if (!value.is<dynamic_t::array_t>())
-			throw config_error() << path << " must be an array";
-
-		const dynamic_t::array_t &array = value.to<dynamic_t::array_t>();
-
-		T result;
-		for (size_t i = 0; i < array.size(); ++i)
-			result.emplace_back(caster::cast(path + "[" + std::to_string(static_cast<long long int>(i)) + "]", array[i]));
-		return result;
-	}
-};
-
-}
-
-class config
-{
-	typedef blackhole::dynamic_t dynamic_t;
-public:
-	config(const std::string &path, const dynamic_t &value) :
-		m_path(path), m_value(value)
-	{
-	}
-
-	bool has(const std::string &name) const
-	{
-		assert_object();
-
-		return m_value.contains(name);
-	}
-
-	config at(const std::string &name) const
-	{
-		const std::string path = m_path + "." + name;
-		if (!has(name))
-			throw config_error() << path << " is missed";
-
-		const dynamic_t::object_t &object = m_value.to<dynamic_t::object_t>();
-		return config(path, object.find(name)->second);
-	}
-
-	template <typename T>
-	T at(const std::string &name, const T &default_value) const
-	{
-		if (!has(name))
-			return default_value;
-
-		return at(name).as<T>();
-	}
-
-	template <typename T>
-	T at(const std::string &name) const
-	{
-		return at(name).as<T>();
-	}
-
-	size_t size() const
-	{
-		assert_array();
-		return m_value.to<const dynamic_t::array_t &>().size();
-	}
-
-	bool has(size_t index) const
-	{
-		return index < size();
-	}
-
-	config at(size_t index) const
-	{
-		const std::string path = m_path + "[" + std::to_string(static_cast<long long int>(index)) + "]";
-
-		if (!has(index))
-			throw config_error() << path << " is missed";
-
-		return config(path, m_value[index]);
-	}
-
-	template <typename T>
-	T at(size_t index, const T &default_value) const
-	{
-		if (!has(index))
-			return default_value;
-
-		return at(index).as<T>();
-	}
-
-	template <typename T>
-	T at(size_t index) const
-	{
-		return at(index).as<T>();
-	}
-
-	template <typename T>
-	T as() const
-	{
-		assert_valid();
-		return detail::config_value_caster<T>::cast(m_path, m_value);
-	}
-
-	const std::string &path() const
-	{
-		return m_path;
-	}
-
-	std::string to_string() const
-	{
-		assert_valid();
-
-		std::string value_str;
-
-		if (m_value.is<dynamic_t::uint_t>())
-			value_str = std::to_string(static_cast<unsigned long long>(m_value.to<dynamic_t::uint_t>()));
-		else if (m_value.is<dynamic_t::int_t>())
-			value_str = std::to_string(static_cast<long long>(m_value.to<dynamic_t::int_t>()));
-		else if (m_value.is<dynamic_t::double_t>())
-			value_str = std::to_string(static_cast<long double>(m_value.to<dynamic_t::double_t>()));
-		else if (m_value.is<dynamic_t::string_t>())
-			value_str = m_value.to<dynamic_t::string_t>();
-		else
-			throw config_error() << m_path << " has unknown type";
-
-		return value_str;
-	}
-
-	void assert_valid() const
-	{
-		if (m_value.invalid())
-			throw config_error() << m_path << " is missed";
-	}
-
-	void assert_array() const
-	{
-		assert_valid();
-		if (!m_value.is<dynamic_t::array_t>())
-			throw config_error() << m_path << " must be an array";
-	}
-
-	void assert_object() const
-	{
-		assert_valid();
-		if (!m_value.is<dynamic_t::object_t>())
-			throw config_error() << m_path << " must be an object";
-	}
-
-	const dynamic_t &raw() const
-	{
-		return m_value;
-	}
-
-protected:
-	std::string m_path;
-	const dynamic_t m_value;
-};
-
-class config_parser
-{
-public:
-	config_parser();
-	~config_parser();
-
-	config open(const std::string &path);
-	config root() const;
-private:
-	blackhole::dynamic_t root_;
-};
-
 struct config_data : public dnet_config_data
 {
 	config_data() : logger(logger_base, blackhole::log::attributes_t())
@@ -348,11 +74,11 @@ struct config_data : public dnet_config_data
 		dnet_empty_time(&config_timestamp);
 	}
 
-	std::shared_ptr<config_parser> parse_config();
+	std::shared_ptr<kora::config_parser_t> parse_config();
 
 	std::string					config_path;
 	std::mutex					parser_mutex;
-	std::shared_ptr<config_parser>			parser;
+	std::shared_ptr<kora::config_parser_t>		parser;
 	dnet_time					config_timestamp;
 	dnet_backend_info_manager			backends_guard;
 	std::string					logger_value;
@@ -364,7 +90,7 @@ struct config_data : public dnet_config_data
 	uint64_t					queue_timeout;
 };
 
-std::shared_ptr<dnet_backend_info> dnet_parse_backend(config_data *data, uint32_t backend_id, const config &backend);
+std::shared_ptr<dnet_backend_info> dnet_parse_backend(config_data *data, uint32_t backend_id, const kora::config_t &backend);
 
 } } } // namespace ioremap::elliptics::config
 

--- a/example/config_impl.cpp
+++ b/example/config_impl.cpp
@@ -1,94 +1,12 @@
 #include "config.hpp"
 
-#include <blackhole/repository/config/parser/rapidjson.hpp>
-
-#include <rapidjson/document.h>
-#include <rapidjson/filestream.h>
-
 #include <fstream>
+#include <kora/dynamic.hpp>
+#include <kora/config.hpp>
 
 using namespace ioremap::elliptics::config;
 
-config_parser::config_parser()
-{
-}
-
-config_parser::~config_parser()
-{
-}
-
-config config_parser::open(const std::string &path)
-{
-	FILE *f = fopen(path.c_str(), "r");
-	if (!f) {
-		int err = -errno;
-		throw config_error() << "failed to open config file'" << path << "': " << strerror(-err);
-	}
-
-	rapidjson::FileStream stream(f);
-
-	rapidjson::Document doc;
-	doc.ParseStream<0>(stream);
-
-	fclose(f);
-
-	if (doc.HasParseError()) {
-		std::ifstream in(path.c_str());
-		if (in) {
-			size_t offset = doc.GetErrorOffset();
-			std::vector<char> buffer(offset);
-			in.read(buffer.data(), offset);
-
-			std::string data(buffer.begin(), buffer.end());
-			std::string line;
-
-			if (std::getline(in, line))
-				data += line;
-
-			/*
-			 * Produce a pretty output about the error
-			 * including the line and certain place where
-			 * the error occured.
-			 */
-
-			size_t line_offset = data.find_last_of('\n');
-			if (line_offset == std::string::npos)
-				line_offset = 0;
-
-			for (size_t i = line_offset; i < data.size(); ++i) {
-				if (data[i] == '\t') {
-					data.replace(i, 1, std::string(4, ' '));
-
-					if (offset > i)
-						offset += 3;
-				}
-			}
-
-			const size_t line_number = std::count(data.begin(), data.end(), '\n') + 1;
-			const size_t dash_count = line_offset < offset ? offset - line_offset - 1 : 0;
-
-			throw config_error()
-				<< "parser error at line " << line_number << ": " << doc.GetParseError() << std::endl
-				<< data.substr(line_offset + 1) << std::endl
-				<< std::string(dash_count, ' ') << '^' << std::endl
-				<< std::string(dash_count, '~') << '+' << std::endl;
-		}
-
-		throw config_error() << "parser error: at unknown line: " << doc.GetParseError();
-	}
-
-	if (!doc.IsObject())
-		throw config_error() << "root must be an object";
-
-	root_ = blackhole::repository::config::transformer_t<rapidjson::Value>::transform(doc);
-	return root();
-}
-
-config config_parser::root() const {
-	return config("<root>", root_);
-}
-
-std::shared_ptr<config_parser> config_data::parse_config() {
+std::shared_ptr<kora::config_parser_t> config_data::parse_config() {
 	struct stat st;
 	dnet_time ts;
 	memset(&st, 0, sizeof(st));
@@ -104,7 +22,7 @@ std::shared_ptr<config_parser> config_data::parse_config() {
 	if (dnet_time_is_empty(&config_timestamp) ||
 	    dnet_time_before(&config_timestamp, &ts)) {
 		config_timestamp = ts;
-		parser = std::make_shared<config_parser>();
+		parser = std::make_shared<kora::config_parser_t>();
 		parser->open(config_path);
 		return parser;
 	} else {

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -52,7 +52,18 @@ set_target_properties(elliptics PROPERTIES
     SOVERSION ${ELLIPTICS_VERSION_ABI}
     LINKER_LANGUAGE CXX
     )
-target_link_libraries(elliptics ${ELLIPTICS_LIBRARIES} ${EBLOB_LIBRARIES} elliptics_common elliptics_cocaine elliptics_cache elliptics_indexes elliptics_ids elliptics_monitor elliptics_client elliptics_cpp)
+target_link_libraries(elliptics
+                      ${ELLIPTICS_LIBRARIES}
+                      ${EBLOB_LIBRARIES}
+                      elliptics_common
+                      elliptics_cocaine
+                      elliptics_cache
+                      elliptics_indexes
+                      elliptics_ids
+                      elliptics_monitor
+                      elliptics_client
+                      elliptics_cpp
+                      kora-util)
 
 install(TARGETS elliptics
     LIBRARY DESTINATION lib${LIB_SUFFIX}

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -947,4 +947,6 @@ void dnet_backend_info::parse(ioremap::elliptics::config::config_data *data,
 			options.emplace_back(std::move(option));
 		}
 	}
+
+	initial_config = kora::to_json(backend.underlying_object());
 }

--- a/library/backend.h
+++ b/library/backend.h
@@ -11,9 +11,9 @@
 #include <mutex>
 
 #include <elliptics/error.hpp>
+#include <kora/config.hpp>
 
 namespace ioremap { namespace elliptics { namespace config {
-class config;
 class config_data;
 }}}
 
@@ -26,7 +26,7 @@ struct cache_config
 	unsigned		sync_timeout;
 	std::vector<size_t>	pages_proportions;
 
-	static std::unique_ptr<cache_config> parse(const ioremap::elliptics::config::config &cache);
+	static std::unique_ptr<cache_config> parse(const kora::config_t &cache);
 };
 
 }}
@@ -43,7 +43,7 @@ struct cache_config
 struct dnet_backend_config_entry
 {
 	dnet_config_entry *entry;
-	std::vector<char> value_template;
+	std::string value_template;
 };
 
 struct dnet_backend_info
@@ -118,7 +118,7 @@ struct dnet_backend_info
 		return *this;
 	}
 
-	void parse(ioremap::elliptics::config::config_data *data, const ioremap::elliptics::config::config &config);
+	void parse(ioremap::elliptics::config::config_data *data, const kora::config_t &config);
 
 	dnet_config_backend config_template;
 	std::unique_ptr<dnet_logger> log;

--- a/library/backend.h
+++ b/library/backend.h
@@ -141,6 +141,7 @@ struct dnet_backend_info
 	std::unique_ptr<ioremap::cache::cache_config> cache_config;
 	int io_thread_num;
 	int nonblocking_io_thread_num;
+	std::string initial_config;
 };
 
 class dnet_backend_info_manager

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -51,6 +51,13 @@ static void fill_backend_backend(rapidjson::Value &stat_value,
 			rapidjson::Document backend_value(&allocator);
 			backend_value.Parse<0>(json_stat);
 			backend_value["config"].AddMember("group", config_backend->group, allocator);
+
+			rapidjson::Document initial_config(&allocator);
+			initial_config.Parse<0>(config_backend->initial_config.c_str());
+			backend_value.AddMember("initial_config",
+			                        static_cast<rapidjson::Value&>(initial_config),
+			                        allocator);
+
 			stat_value.AddMember("backend",
 			                     static_cast<rapidjson::Value&>(backend_value),
 			                     allocator);

--- a/monitor/monitor.cpp
+++ b/monitor/monitor.cpp
@@ -50,14 +50,14 @@ monitor_config* get_monitor_config(struct dnet_node *n) {
 	return data.monitor_config.get();
 }
 
-std::unique_ptr<monitor_config> monitor_config::parse(const elliptics::config::config &monitor)
+std::unique_ptr<monitor_config> monitor_config::parse(const kora::config_t &monitor)
 {
 	monitor_config cfg;
 	cfg.monitor_port = monitor.at<unsigned int>("port", 0);
 
 	cfg.has_top = monitor.has("top");
 	if (cfg.has_top) {
-		const elliptics::config::config top = monitor.at("top");
+		const auto top = monitor["top"];
 		cfg.top_length = top.at<size_t>("top_length", DNET_DEFAULT_MONITOR_TOP_LENGTH);
 		cfg.events_size = top.at<size_t>("events_size", DNET_DEFAULT_MONITOR_TOP_EVENTS_SIZE);
 		cfg.period_in_seconds = top.at<int>("period_in_seconds", DNET_DEFAULT_MONITOR_TOP_PERIOD);

--- a/monitor/monitor.hpp
+++ b/monitor/monitor.hpp
@@ -42,7 +42,7 @@ struct monitor_config
 	size_t		events_size;
 	int		period_in_seconds;
 
-	static std::unique_ptr<monitor_config> parse(const ioremap::elliptics::config::config &monitor);
+	static std::unique_ptr<monitor_config> parse(const kora::config_t &monitor);
 };
 
 class stat_provider;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,7 +150,7 @@ add_test_target(test_capped dnet_cpp_capped_test DEPENDS ${TESTS_DEPS})
 
 add_executable(dnet_backends_test backends_test.cpp)
 set_target_properties(dnet_backends_test ${TEST_PROPERTIES})
-target_link_libraries(dnet_backends_test ${TEST_LIBRARIES})
+target_link_libraries(dnet_backends_test ${TEST_LIBRARIES} kora-util)
 add_test_target(test_backends dnet_backends_test DEPENDS ${TESTS_DEPS})
 
 add_executable(dnet_weights_test weights_test.cpp)


### PR DESCRIPTION
Use libkora-util instead of `dynamic_t` from `blackhole` and internal implementation of `config_t` and `config_parser_t`.

Store and provide via monitor all json objects used in each backend initialization.