### PR TITLE
support newapi by cache

### DIFF
--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -45,7 +45,8 @@ std::unique_ptr<cache_config> cache_config::parse(const kora::config_t &cache)
 	config.size = size.to<size_t>();
 	config.count = cache.at<size_t>("shards", DNET_DEFAULT_CACHES_NUMBER);
 	config.sync_timeout = cache.at<unsigned>("sync_timeout", DNET_DEFAULT_CACHE_SYNC_TIMEOUT_SEC);
-	config.pages_proportions = cache.at("pages_proportions", std::vector<size_t>(DNET_DEFAULT_CACHE_PAGES_NUMBER, 1));
+	config.pages_proportions =
+	    cache.at("pages_proportions", std::vector<size_t>(DNET_DEFAULT_CACHE_PAGES_NUMBER, 1));
 	return blackhole::utils::make_unique<cache_config>(config);
 }
 
@@ -73,7 +74,11 @@ cache_manager::cache_manager(dnet_backend_io *backend, dnet_node *n, const cache
 cache_manager::~cache_manager() {
 }
 
-int cache_manager::write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data) {
+int cache_manager::write(const unsigned char *id,
+                         dnet_net_state *st,
+                         dnet_cmd *cmd,
+                         dnet_io_attr *io,
+                         const char *data) {
 	return m_caches[idx(id)]->write(id, st, cmd, io, data);
 }
 
@@ -148,15 +153,18 @@ std::vector<cache_stats> cache_manager::get_caches_stats() const {
 	return caches_stats;
 }
 
-rapidjson::Value &cache_manager::get_total_caches_size_stats_json(rapidjson::Value &stat_value, rapidjson::Document::AllocatorType &allocator) const {
+rapidjson::Value &cache_manager::get_total_caches_size_stats_json(rapidjson::Value &stat_value,
+                                                                  rapidjson::Document::AllocatorType &allocator) const {
 	cache_stats stats = get_total_cache_stats();
 	return stats.to_json(stat_value, allocator);
 }
 
-rapidjson::Value &cache_manager::get_caches_size_stats_json(rapidjson::Value &stat_value, rapidjson::Document::AllocatorType &allocator) const {
+rapidjson::Value &cache_manager::get_caches_size_stats_json(rapidjson::Value &stat_value,
+                                                            rapidjson::Document::AllocatorType &allocator) const {
 	for (size_t i = 0; i < m_caches.size(); ++i) {
 		rapidjson::Value cache_time_stats(rapidjson::kObjectType);
-		stat_value.AddMember(std::to_string(static_cast<unsigned long long>(i)).c_str(), allocator, m_caches[i]->get_cache_stats().to_json(cache_time_stats, allocator), allocator);
+		stat_value.AddMember(std::to_string(static_cast<unsigned long long>(i)).c_str(), allocator,
+		                     m_caches[i]->get_cache_stats().to_json(cache_time_stats, allocator), allocator);
 	}
 	return stat_value;
 }
@@ -194,7 +202,11 @@ size_t cache_manager::idx(const unsigned char *id) {
 
 using namespace ioremap::cache;
 
-int dnet_cmd_cache_io(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, struct dnet_io_attr *io, char *data)
+int dnet_cmd_cache_io(struct dnet_backend_io *backend,
+                      struct dnet_net_state *st,
+                      struct dnet_cmd *cmd,
+                      struct dnet_io_attr *io,
+                      char *data)
 {
 	struct dnet_node *n = st->n;
 	int err = -ENOTSUP;

--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -77,7 +77,7 @@ int cache_manager::write(const unsigned char *id, dnet_net_state *st, dnet_cmd *
 	return m_caches[idx(id)]->write(id, st, cmd, io, data);
 }
 
-std::shared_ptr<raw_data_t> cache_manager::read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io) {
+std::shared_ptr<std::string> cache_manager::read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io) {
 	return m_caches[idx(id)]->read(id, cmd, io);
 }
 
@@ -207,7 +207,7 @@ int dnet_cmd_cache_io(struct dnet_backend_io *backend, struct dnet_net_state *st
 	}
 
 	cache_manager *cache = (cache_manager *)backend->cache;
-	std::shared_ptr<raw_data_t> d;
+	std::shared_ptr<std::string> d;
 
 	FORMATTED(HANDY_TIMER_SCOPE, ("cache.%s", dnet_cmd_string(cmd->cmd)));
 
@@ -257,7 +257,7 @@ int dnet_cmd_cache_io(struct dnet_backend_io *backend, struct dnet_net_state *st
 				io->total_size = d->size();
 
 				cmd->flags &= ~DNET_FLAGS_NEED_ACK;
-				err = dnet_send_read_data(st, cmd, io, (char *)d->data().data() + io->offset, -1, io->offset, 0);
+				err = dnet_send_read_data(st, cmd, io, &d->at(io->offset), -1, io->offset, 0);
 				break;
 			case DNET_CMD_DEL:
 				err = cache->remove(cmd->id.id, io);

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -44,14 +44,14 @@ namespace ioremap { namespace cache {
 
 struct data_lru_tag_t;
 typedef boost::intrusive::list_base_hook<boost::intrusive::tag<data_lru_tag_t>,
-boost::intrusive::link_mode<boost::intrusive::safe_link>, boost::intrusive::optimize_size<true>
-> lru_list_base_hook_t;
+                                         boost::intrusive::link_mode<boost::intrusive::safe_link>,
+                                         boost::intrusive::optimize_size<true>>
+    lru_list_base_hook_t;
 
 class data_t;
 
 template<>
-struct treap_node_traits<data_t>
-{
+struct treap_node_traits<data_t> {
 	typedef const uint8_t* key_type;
 	typedef size_t priority_type;
 };
@@ -140,16 +140,13 @@ public:
 
 	size_t eventtime() const {
 		size_t time = 0;
-		if (!time || (lifetime() && time > lifetime()))
-		{
+		if (!time || (lifetime() && time > lifetime())) {
 			time = lifetime();
 		}
-		if (!time || (synctime() && time > synctime()))
-		{
+		if (!time || (synctime() && time > synctime())) {
 			time = synctime();
 		}
-		if (!time)
-		{
+		if (!time) {
 			time = std::numeric_limits<size_t>::max();
 		}
 		return time;
@@ -349,9 +346,13 @@ struct eventtime_less {
 typedef treap<data_t> treap_t;
 
 struct cache_stats {
-	cache_stats():
-		number_of_objects(0), size_of_objects(0),
-		number_of_objects_marked_for_deletion(0), size_of_objects_marked_for_deletion(0) {}
+	cache_stats()
+	: number_of_objects(0)
+	, size_of_objects(0)
+	, number_of_objects_marked_for_deletion(0)
+	, size_of_objects_marked_for_deletion(0)
+	{
+	}
 
 	std::size_t number_of_objects;
 	std::size_t size_of_objects;
@@ -385,60 +386,62 @@ struct cache_stats {
 class slru_cache_t;
 
 class cache_manager {
-	public:
-		cache_manager(dnet_backend_io *backend, dnet_node *n, const cache_config &config);
+public:
+	cache_manager(dnet_backend_io *backend, dnet_node *n, const cache_config &config);
 
-		~cache_manager();
+	~cache_manager();
 
-		int write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data);
+	int write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data);
 
-		std::shared_ptr<std::string> read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io);
+	std::shared_ptr<std::string> read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io);
 
-		int remove(const unsigned char *id, dnet_io_attr *io);
+	int remove(const unsigned char *id, dnet_io_attr *io);
 
-		int lookup(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd);
+	int lookup(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd);
 
-		int indexes_find(dnet_cmd *cmd, dnet_indexes_request *request);
+	int indexes_find(dnet_cmd *cmd, dnet_indexes_request *request);
 
-		int indexes_update(dnet_cmd *cmd, dnet_indexes_request *request);
+	int indexes_update(dnet_cmd *cmd, dnet_indexes_request *request);
 
-		int indexes_internal(dnet_cmd *cmd, dnet_indexes_request *request);
+	int indexes_internal(dnet_cmd *cmd, dnet_indexes_request *request);
 
-		void clear();
+	void clear();
 
-		size_t cache_size() const;
+	size_t cache_size() const;
 
-		size_t cache_pages_number() const;
+	size_t cache_pages_number() const;
 
-		cache_stats get_total_cache_stats() const;
+	cache_stats get_total_cache_stats() const;
 
-		std::vector<cache_stats> get_caches_stats() const;
+	std::vector<cache_stats> get_caches_stats() const;
 
-		rapidjson::Value& get_total_caches_size_stats_json(rapidjson::Value& stat_value, rapidjson::Document::AllocatorType &allocator) const;
+	rapidjson::Value &get_total_caches_size_stats_json(rapidjson::Value &stat_value,
+	                                                   rapidjson::Document::AllocatorType &allocator) const;
 
-		rapidjson::Value& get_total_caches_time_stats_json(rapidjson::Value& stat_value, rapidjson::Document::AllocatorType &allocator) const;
+	rapidjson::Value &get_total_caches_time_stats_json(rapidjson::Value &stat_value,
+	                                                   rapidjson::Document::AllocatorType &allocator) const;
 
-		rapidjson::Value& get_caches_size_stats_json(rapidjson::Value& stat_value, rapidjson::Document::AllocatorType &allocator) const;
+	rapidjson::Value &get_caches_size_stats_json(rapidjson::Value &stat_value,
+	                                             rapidjson::Document::AllocatorType &allocator) const;
 
-		rapidjson::Value& get_caches_time_stats_json(rapidjson::Value& stat_value, rapidjson::Document::AllocatorType &allocator) const;
+	rapidjson::Value &get_caches_time_stats_json(rapidjson::Value &stat_value,
+	                                             rapidjson::Document::AllocatorType &allocator) const;
 
-		std::string stat_json() const;
+	std::string stat_json() const;
 
-	private:
-		dnet_node *m_node;
-		std::vector<std::shared_ptr<slru_cache_t>> m_caches;
-		size_t m_max_cache_size;
-		size_t m_cache_pages_number;
+private:
+	dnet_node *m_node;
+	std::vector<std::shared_ptr<slru_cache_t>> m_caches;
+	size_t m_max_cache_size;
+	size_t m_cache_pages_number;
 
-		size_t idx(const unsigned char *id);
+	size_t idx(const unsigned char *id);
 };
 
-template <typename T>
-class elliptics_unique_lock
-{
+template <typename T> class elliptics_unique_lock {
 public:
-	elliptics_unique_lock(T &mutex, dnet_node *node, const char *format, ...) __attribute__ ((format(printf, 4, 5)))
-		: m_node(node)
+	elliptics_unique_lock(T &mutex, dnet_node *node, const char *format, ...) __attribute__((format(printf, 4, 5)))
+	: m_node(node)
 	{
 		va_list args;
 		va_start(args, format);
@@ -455,7 +458,8 @@ public:
 			level = DNET_LOG_ERROR;
 
 		if (m_timer.elapsed() > 0) {
-			dnet_log(m_node, level, "%s: cache lock: constructor: vatime: %ld, total: %lld ms", m_name, vatime, m_timer.elapsed());
+			dnet_log(m_node, level, "%s: cache lock: constructor: vatime: %ld, total: %lld ms", m_name,
+			         vatime, m_timer.elapsed());
 		}
 
 		m_timer.restart();
@@ -509,6 +513,6 @@ private:
 	elliptics_timer m_timer;
 };
 
-}}
+}} /* namespace ioremap::cache */
 
 #endif // CACHE_HPP

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -24,11 +24,7 @@
 #include <cstdio>
 #include <unordered_map>
 #include <limits>
-#if __GNUC__ == 4 && __GNUC_MINOR__ < 5
-#  include <cstdatomic>
-#else
-#  include <atomic>
-#endif
+#include <atomic>
 
 #include <boost/intrusive/list.hpp>
 

--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -144,9 +144,6 @@ int slru_cache_t::write(const unsigned char *id, dnet_net_state *st, dnet_cmd *c
 
 			sync_after_append(guard, false, &*it);
 
-			local_session sess(m_backend, m_node);
-			sess.set_ioflags(DNET_IO_FLAGS_NOCACHE | DNET_IO_FLAGS_APPEND);
-
 			int err = m_backend->cb->command_handler(st, m_backend->cb->command_private, cmd, io);
 
 			it = populate_from_disk(guard, id, false, &err);
@@ -169,7 +166,7 @@ int slru_cache_t::write(const unsigned char *id, dnet_net_state *st, dnet_cmd *c
 				return err;
 		}
 
-		// Create empty data for code simplifyng
+		// Create empty data for code simplifying
 		if (!it) {
 			it = create_data(id, 0, 0, remove_from_disk);
 			new_page = true;

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -23,7 +23,10 @@ namespace ioremap { namespace cache {
 
 class slru_cache_t {
 public:
-	slru_cache_t(struct dnet_backend_io *backend, struct dnet_node *n, const std::vector<size_t> &cache_pages_max_sizes, unsigned sync_timeout);
+	slru_cache_t(struct dnet_backend_io *backend,
+	             struct dnet_node *n,
+	             const std::vector<size_t> &cache_pages_max_sizes,
+	             unsigned sync_timeout);
 
 	~slru_cache_t();
 
@@ -78,13 +81,16 @@ private:
 	void remove_data_from_page(const unsigned char *id, size_t page_number, data_t *data);
 
 	void move_data_between_pages(const unsigned char *id,
-								 size_t source_page_number,
-								 size_t destination_page_number,
-								 data_t *data);
+	                             size_t source_page_number,
+	                             size_t destination_page_number,
+	                             data_t *data);
 
 	data_t* create_data(const unsigned char *id, const char *data, size_t size, bool remove_from_disk);
 
-	data_t* populate_from_disk(elliptics_unique_lock<std::mutex> &guard, const unsigned char *id, bool remove_from_disk, int *err);
+	data_t *populate_from_disk(elliptics_unique_lock<std::mutex> &guard,
+	                           const unsigned char *id,
+	                           bool remove_from_disk,
+	                           int *err);
 
 	bool have_enough_space(const unsigned char *id, size_t page_number, size_t reserve);
 
@@ -92,7 +98,11 @@ private:
 
 	void erase_element(data_t *obj);
 
-	void sync_element(const dnet_id &raw, bool after_append, const std::string &data, uint64_t user_flags, const dnet_time &timestamp);
+	void sync_element(const dnet_id &raw,
+	                  bool after_append,
+	                  const std::string &data,
+	                  uint64_t user_flags,
+	                  const dnet_time &timestamp);
 
 	void sync_element(data_t *obj);
 
@@ -101,7 +111,7 @@ private:
 	void life_check(void);
 };
 
-}}
+}} /* namespace ioremap::cache */
 
 
 #endif // SLRU_CACHE_HPP

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -29,7 +29,7 @@ public:
 
 	int write(const unsigned char *id, dnet_net_state *st, dnet_cmd *cmd, dnet_io_attr *io, const char *data);
 
-	std::shared_ptr<raw_data_t> read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io);
+	std::shared_ptr<std::string> read(const unsigned char *id, dnet_cmd *cmd, dnet_io_attr *io);
 
 	int remove(const unsigned char *id, dnet_io_attr *io);
 
@@ -92,7 +92,7 @@ private:
 
 	void erase_element(data_t *obj);
 
-	void sync_element(const dnet_id &raw, bool after_append, const std::vector<char> &data, uint64_t user_flags, const dnet_time &timestamp);
+	void sync_element(const dnet_id &raw, bool after_append, const std::string &data, uint64_t user_flags, const dnet_time &timestamp);
 
 	void sync_element(data_t *obj);
 


### PR DESCRIPTION
### DO NOT MERGE

This PR will add support newapi to cache. It will be done in follow steps:
- [x] update internal structures which stores keys' meta-data and data in memory

- [ ]  handle `READ_NEW`, `WRITE_NEW` and `LOOKUP_NEW` in cache

- [ ] sync keys' json and its meta-data between cache and disk