### PR TITLE
pytests: fix srw tests which occasionally fails

### DIFF
--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -117,30 +117,24 @@ def make_session(node, test_name, test_namespace=None):
 #
 
 @pytest.yield_fixture(scope="session")
-def server(request):
+def servers(request):
     '''
     Creates elliptics server nodes to work against.
     Returns node ensemble configuration.
     '''
     groups = [int(g) for g in request.config.option.groups.split(',')]
 
-    servers = Servers(groups=groups,
-                      without_cocaine=request.config.option.without_cocaine,
-                      nodes_count=int(request.config.option.nodes_count),
-                      backends_count=int(request.config.option.backends_count))
+    _servers = Servers(groups=groups,
+                       without_cocaine=request.config.option.without_cocaine,
+                       nodes_count=int(request.config.option.nodes_count),
+                       backends_count=int(request.config.option.backends_count))
 
-    request.config.option.remotes = servers.remotes
-    request.config.option.monitors = servers.monitors
+    request.config.option.remotes = _servers.remotes
+    request.config.option.monitors = _servers.monitors
 
-    yield servers
+    yield _servers
 
-    servers.stop()
-
-
-# Fixture `server` named a bit off because it actually creates
-# an ensemble of server nodes.
-# Plural is more proper.
-servers = server
+    _servers.stop()
 
 
 @pytest.fixture(scope='session')

--- a/tests/pytests/test_monitor_top.py
+++ b/tests/pytests/test_monitor_top.py
@@ -61,7 +61,7 @@ class TestMonitorTop:
     It checks that top keys service exists and items of top keys list contains all required fields.
     '''
 
-    def test_single_write(self, server, simple_node):
+    def test_single_write(self, servers, simple_node):
         '''
         check that single access to some key appears among top keys using http interface of monitoring service
         '''
@@ -76,11 +76,11 @@ class TestMonitorTop:
 
         test_key = hashlib.sha512(test_key).hexdigest()
         top_keys = []
-        for remote, port in zip(server.remotes, server.monitors):
+        for remote, port in zip(servers.remotes, servers.monitors):
             remote = remote.split(':')[0]
             response = get_top_by_http(remote, port)
             # check that response contains required fields
-            check_response_fields(response, server.config_params)
+            check_response_fields(response, servers.config_params)
             top_keys = response['top']['top_by_size']
             if has_key(test_key, top_keys):
                 break
@@ -89,7 +89,7 @@ class TestMonitorTop:
         # check that all top keys items contains all required fields
         check_key_fields(top_keys)
 
-        self.__check_key_existance_using_session_monitor(session, server.config_params, test_key)
+        self.__check_key_existance_using_session_monitor(session, servers.config_params, test_key)
 
     def __check_key_existance_using_session_monitor(self, session, config_params, test_key):
         '''

--- a/tests/pytests/test_newapi.py
+++ b/tests/pytests/test_newapi.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import make_trace_id
 
 
-@pytest.mark.usefixtures('server')
+@pytest.mark.usefixtures('servers')
 def test_lookup_read_nonexistent_key(simple_node):
     """Try to lookup and read a non-existent key and validate fields of results."""
     session = elliptics.newapi.Session(simple_node)
@@ -30,7 +30,7 @@ def test_lookup_read_nonexistent_key(simple_node):
         assert result.data is None
 
 
-@pytest.mark.usefixtures('server')
+@pytest.mark.usefixtures('servers')
 def test_lookup_read_existent_key(simple_node):
     """Write a key, lookup and read it and validate fields of results."""
     session = elliptics.newapi.Session(simple_node)
@@ -69,7 +69,7 @@ def test_lookup_read_existent_key(simple_node):
     assert i == 1
 
 
-@pytest.mark.usefixtures('server')
+@pytest.mark.usefixtures('servers')
 def test_use_session_clone(simple_node):
     """Create session, clone and write a key by clone."""
     session = elliptics.newapi.Session(simple_node)
@@ -87,7 +87,7 @@ def test_use_session_clone(simple_node):
     clone.remove(key)
 
 
-@pytest.mark.usefixtures('server')
+@pytest.mark.usefixtures('servers')
 def test_session_timestamps(simple_node):
     """Test session.timestamp and session.json_timestamp."""
     session = elliptics.newapi.Session(simple_node)

--- a/tests/pytests/test_recovery.py
+++ b/tests/pytests/test_recovery.py
@@ -246,7 +246,8 @@ class TestRecovery:
     # timestamp of corrupted_key from second group which should be recovered to first and third group
     corrupted_timestamp2 = elliptics.Time(corrupted_timestamp.tsec + 3600, corrupted_timestamp.tnsec)
 
-    def test_disable_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_disable_backends(self, simple_node):
         '''
         Turns off all backends from all node except one.
         '''
@@ -289,7 +290,8 @@ class TestRecovery:
         # checks that routes contains only chosen backend group
         assert session.routes.groups() == (scope.test_group, )
 
-    def test_prepare_data(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_prepare_data(self, simple_node):
         '''
         Writes self.keys to chosen group and checks their availability.
         '''
@@ -302,7 +304,8 @@ class TestRecovery:
         write_data(scope, session, self.keys, self.datas)
         check_data(scope, session, self.keys, self.datas, self.timestamp)
 
-    def test_enable_group_one_backend(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_group_one_backend(self, simple_node):
         '''
         Turns on one backend from the same group.
         '''
@@ -315,7 +318,7 @@ class TestRecovery:
         check_backend_status(r.get(), backend, state=1)
         wait_backends_in_route(session, ((address, backend),))
 
-    def test_merge_two_backends(self, server, simple_node):
+    def test_merge_two_backends(self, servers, simple_node):
         '''
         Runs dnet_recovery merge with --one-node=scope.test_address and --backend-id==scope.test_backend.
         Checks self.keys availability after recovering.
@@ -325,7 +328,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
 
         recovery(one_node=True,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=scope.test_backend,
                  address=scope.test_address,
                  groups=(scope.test_group,),
@@ -338,7 +341,8 @@ class TestRecovery:
         check_data(scope, session, self.keys, self.datas, self.timestamp)
         check_keys_absence(scope, session, self.keys)
 
-    def test_enable_another_one_backend(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_another_one_backend(self, simple_node):
         '''
         Enables another one backend from the same group.
         '''
@@ -351,7 +355,8 @@ class TestRecovery:
         check_backend_status(r.get(), backend, state=1)
         wait_backends_in_route(session, ((address, backend),))
 
-    def test_merge_from_dump_3_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_merge_from_dump_3_backends(self, servers, simple_node):
         '''
         Writes all keys to dump file: 'merge.dump.file'.
         Runs dnet_recovery merge without --one-node and without --backend-id and with -f merge.dump.file.
@@ -367,7 +372,7 @@ class TestRecovery:
                 dump_file.write('{0}\n'.format(str(session.transform(key))))
 
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.test_address,
                  groups=(scope.test_group,),
@@ -380,7 +385,8 @@ class TestRecovery:
         check_data(scope, session, self.keys, self.datas, self.timestamp)
         check_keys_absence(scope, session, self.keys)
 
-    def test_enable_all_group_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_all_group_backends(self, simple_node):
         '''
         Enables all backends from all nodes from first group
         '''
@@ -389,7 +395,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
         enable_group(scope, session, scope.test_group)
 
-    def test_merge_one_group(self, server, simple_node):
+    def test_merge_one_group(self, servers, simple_node):
         '''
         Runs dnet_recovery merge without --one-node and without --backend-id.
         Checks self.keys availability after recovering.
@@ -399,7 +405,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
 
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.test_address,
                  groups=(scope.test_group,),
@@ -411,7 +417,8 @@ class TestRecovery:
         check_data(scope, session, self.keys, self.datas, self.timestamp)
         check_keys_absence(scope, session, self.keys)
 
-    def test_enable_second_group_one_backend(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_second_group_one_backend(self, simple_node):
         '''
         Enables one backend from one node from second group.
         '''
@@ -426,7 +433,7 @@ class TestRecovery:
         check_backend_status(r.get(), backend, state=1)
         wait_backends_in_route(session, ((address, backend), ))
 
-    def test_dc_one_backend_and_one_group(self, server, simple_node):
+    def test_dc_one_backend_and_one_group(self, servers, simple_node):
         '''
         Runs dnet_recovery dc with --one-node=scope.test_address2,
         --backend-id=scope.test_backend2 and against both groups.
@@ -437,7 +444,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
 
         recovery(one_node=True,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=scope.test_backend2,
                  address=scope.test_address2,
                  groups=(scope.test_group, scope.test_group2,),
@@ -449,7 +456,8 @@ class TestRecovery:
         session.groups = (scope.test_group2,)
         check_data(scope, session, self.keys, self.datas, self.timestamp)
 
-    def test_enable_all_second_group_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_all_second_group_backends(self, simple_node):
         '''
         Enables all backends from all node in second group.
         '''
@@ -458,7 +466,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
         enable_group(scope, session, scope.test_group2)
 
-    def test_dc_from_dump_two_groups(self, server, simple_node):
+    def test_dc_from_dump_two_groups(self, servers, simple_node):
         '''
         Runs dnet_recovery dc without --one-node and
         without --backend-id against both groups and with -f merge.dump.file.
@@ -474,7 +482,7 @@ class TestRecovery:
                 dump_file.write('{0}\n'.format(str(session.transform(key))))
 
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.test_address2,
                  groups=(scope.test_group, scope.test_group2,),
@@ -489,7 +497,8 @@ class TestRecovery:
         session.groups = (scope.test_group2,)
         check_data(scope, session, self.keys, self.datas, self.timestamp)
 
-    def test_enable_all_third_group_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_all_third_group_backends(self, simple_node):
         '''
         Enables all backends from all node from third group.
         '''
@@ -498,7 +507,8 @@ class TestRecovery:
                                test_namespace=self.namespace)
         enable_group(scope, session, scope.test_group3)
 
-    def test_write_data_to_third_group(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_data_to_third_group(self, simple_node):
         '''
         Writes different data by self.key in third group
         '''
@@ -511,7 +521,7 @@ class TestRecovery:
         write_data(scope, session, self.keys, self.datas2)
         check_data(scope, session, self.keys, self.datas2, self.timestamp2)
 
-    def test_dc_three_groups(self, server, simple_node):
+    def test_dc_three_groups(self, servers, simple_node):
         '''
         Run dc recovery without --one-node and without --backend-id against all three groups.
         Checks that all three groups contain data from third group.
@@ -521,7 +531,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
 
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.test_address2,
                  groups=(scope.test_group, scope.test_group2, scope.test_group3),
@@ -533,7 +543,8 @@ class TestRecovery:
             session.groups = [group]
             check_data(scope, session, self.keys, self.datas2, self.timestamp2)
 
-    def test_write_and_corrupt_data(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_and_corrupt_data(self, simple_node):
         '''
         Writes one by one the key with different data and
         incremental timestamp to groups 1, 2, 3 and corrupts data in the group #3.
@@ -568,7 +579,7 @@ class TestRecovery:
             f.write(tmp)
             f.flush()
 
-    def test_dc_corrupted_data(self, server, simple_node):
+    def test_dc_corrupted_data(self, servers, simple_node):
         '''
         Runs dc recovery and checks that second version of data is recovered to all groups.
         This test checks that dc recovery correctly handles corrupted key on his way:
@@ -580,7 +591,7 @@ class TestRecovery:
                                test_namespace=self.namespace)
 
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.test_address2,
                  groups=(scope.test_group, scope.test_group2, scope.test_group3),
@@ -592,7 +603,8 @@ class TestRecovery:
             session.groups = [group]
             check_data(scope, session, [self.corrupted_key], [self.corrupted_data + '.2'], self.corrupted_timestamp2)
 
-    def test_defragmentation(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_defragmentation(self, simple_node):
         '''
         Runs defragmentation on all backends from all nodes and groups.
         Waiting defragmentation stops and checks results.
@@ -631,7 +643,8 @@ class TestRecovery:
             session.groups = [group]
             check_data(scope, session, self.keys, self.datas2, self.timestamp2)
 
-    def test_enable_rest_backends(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_enable_rest_backends(self, simple_node):
         '''
         Restore all groups with all nodes and all backends.
         '''
@@ -641,7 +654,8 @@ class TestRecovery:
         for g in scope.test_other_groups:
             enable_group(scope, session, g)
 
-    def test_checks_all_enabled(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_checks_all_enabled(self, simple_node):
         '''
         Checks statuses of all backends from all nodes and groups
         '''
@@ -848,7 +862,8 @@ class TestMerge:
             time.sleep(0.5)
             counter += 0.5
 
-    def test_setup(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_setup(self, simple_node):
         '''
         Initial test cases that prepare test cluster before running recovery. It includes:
         1. preparing whole test class scope - making session, choosing node and backends etc.
@@ -879,12 +894,12 @@ class TestMerge:
         self.cleanup_backends(tuple((self.scope.address, b) for b in self.scope.backends))
         self.prepare_test_data()
 
-    def test_recovery(self, server, simple_node):
+    def test_recovery(self, servers, simple_node):
         '''
         Runs recovery and checks recovery result
         '''
         recovery(one_node=False,
-                 remotes=map(elliptics.Address.from_host_port_family, server.remotes),
+                 remotes=map(elliptics.Address.from_host_port_family, servers.remotes),
                  backend_id=None,
                  address=scope.address,
                  groups=(scope.group,),
@@ -893,7 +908,8 @@ class TestMerge:
                  log_file='merge_with_uncommitted_keys.log',
                  tmp_dir='merge_with_uncommitted_keys')
 
-    def test_check(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_check(self, simple_node):
         '''
         Checks that all keys from test_data are in correct state - have correct timestamp and availability.
         '''
@@ -919,7 +935,8 @@ class TestMerge:
                 assert result.timestamp == check_ts
                 assert result.data == self.data
 
-    def test_teardown(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_teardown(self, simple_node):
         self.cleanup_backends(scope.routes.addresses_with_backends())
 
 
@@ -1023,7 +1040,8 @@ class TestDC:
             assert result[0].timestamp == ts
             assert result[0].group_id == group
 
-    def test_setup(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_setup(self, simple_node):
         '''
         Initial test cases that prepare test cluster before running recovery. It includes:
         1. preparing whole test class scope - making session, choosing node and backends etc.
@@ -1043,7 +1061,8 @@ class TestDC:
         self.cleanup_backends()
         self.prepare_test_data()
 
-    def test_recovery(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_recovery(self, simple_node):
         '''
         Runs recovery and checks recovery result
         '''
@@ -1056,7 +1075,8 @@ class TestDC:
                  log_file='dc_with_uncommitted_keys.log',
                  tmp_dir='dc_with_uncommitted_keys')
 
-    def test_check(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_check(self, simple_node):
         '''
         Checks that all keys from test_data are in correct state - have correct timestamp and availability.
         '''
@@ -1095,7 +1115,8 @@ class TestDC:
                     assert result.timestamp == check_ts[i]
                     assert result.data == self.data
 
-    def test_teardown(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_teardown(self, simple_node):
         self.cleanup_backends()
 
 
@@ -1173,7 +1194,8 @@ class TestRecoveryUserFlags:
             counter += 0.5
 
 
-    def test_setup(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_setup(self, simple_node):
         '''
         Initial test cases that prepare test cluster before running recovery. It includes:
         1. preparing whole test class scope - making session, choosing node and backends etc.
@@ -1191,7 +1213,8 @@ class TestRecoveryUserFlags:
         self.cleanup_backends()
         self.prepare_test_data()
 
-    def test_recovery(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_recovery(self, simple_node):
         '''
         Runs recovery with filtration of keys by specifying user_flags_set and checks that:
         1. test_key shouldn't be recovered
@@ -1227,5 +1250,6 @@ class TestRecoveryUserFlags:
             results = session.read_data(self.test_key3).get()
             assert all(r.user_flags not in self.user_flags_set for r in results)
 
-    def test_teardown(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_teardown(self, simple_node):
         self.cleanup_backends()

--- a/tests/pytests/test_session_indexes.py
+++ b/tests/pytests/test_session_indexes.py
@@ -15,6 +15,7 @@
 
 import sys
 sys.path.insert(0, "")  # for running from cmake
+import pytest
 from conftest import make_session
 import elliptics
 
@@ -61,7 +62,8 @@ class TestSession:
                                 indexes,
                                 datas)
 
-    def test_indexes_simple(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_indexes_simple(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_indexes_simple')
         session.groups = session.routes.groups()
@@ -92,7 +94,8 @@ class TestSession:
             del check_dict[idx]
         self.check_indexes(session, key, check_dict.keys(), check_dict.values())
 
-    def test_indexes_dict(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_indexes_dict(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_indexes_dict')
         session.groups = session.routes.groups()

--- a/tests/pytests/test_session_iterator.py
+++ b/tests/pytests/test_session_iterator.py
@@ -113,7 +113,8 @@ class TestSession:
     It sanity checks all available interface and doesn't check correctness of data and metadata,
     because these tests doesn't know anything about these keys.
     '''
-    def test_iterate_default(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_default(self, simple_node):
         '''
         Runs iterator on first node/backend from route-list without specified ranges and special flags
         Checks iterated keys by check_iterator_results.
@@ -136,7 +137,8 @@ class TestSession:
 
         check_iterator_results(first_node, first_backend, iterator, session, node_id)
 
-    def test_iterate_one_range(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_one_range(self, simple_node):
         '''
         Runs iterator on first node/backend from route-list with using only first range of it.
         Checks iterated keys by check_iterator_results.
@@ -161,7 +163,8 @@ class TestSession:
 
         check_iterator_results(node, backend, iterator, session, node_id)
 
-    def test_iterate_all_node_ranges(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_all_node_ranges(self, simple_node):
         '''
         Runs iterator on first node/backend from route-list with using all ranges covered by it.
         Checks iterated keys by check_iterator_results.
@@ -182,7 +185,8 @@ class TestSession:
 
         check_iterator_results(node, backend, iterator, session, node_id)
 
-    def test_iterate_all_node_ranges_with_timestamp(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_all_node_ranges_with_timestamp(self, simple_node):
         '''
         Runs iterator on first node/backend from route-list with using all ranges covered by it
         and timetamps that specifies period from 30 second before now to now.
@@ -208,7 +212,8 @@ class TestSession:
 
         check_iterator_results(node, backend, iterator, session, node_id)
 
-    def test_iterate_inverted_node_ranges_with_data(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_inverted_node_ranges_with_data(self, simple_node):
         '''
         Runs iterator on first node/backend from route-list with using inverted ranges
         that aren't covered by this node/backend.
@@ -230,7 +235,8 @@ class TestSession:
 
         check_iterator_results(node, backend, iterator, session, node_id)
 
-    def test_iterate_all_node_ranges_no_meta(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_iterate_all_node_ranges_no_meta(self, simple_node):
         '''
         Runs iterator with no_meta on first node/backend from route-list with using all ranges covered by it.
         Checks iterated keys by check_iterator_results.

--- a/tests/pytests/test_session_monitor_and_statistics.py
+++ b/tests/pytests/test_session_monitor_and_statistics.py
@@ -346,7 +346,8 @@ def categories_combination():
 
 
 class TestMonitor:
-    def test_monitor_stat(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_monitor_stat(self, simple_node):
         '''Simply get all statistics from all nodes and check that statistics is valid dict'''
         session = make_session(node=simple_node,
                                test_name='TestSession.test_monitor_stat')
@@ -357,7 +358,8 @@ class TestMonitor:
             assert type(stat.statistics) == dict
 
     @pytest.mark.parametrize("categories", categories_combination())
-    def test_monitor_categories(self, server, simple_node, categories):
+    @pytest.mark.usefixtures("servers")
+    def test_monitor_categories(self, simple_node, categories):
         '''Requests all possible combination of categories one by one and checks statistics'''
         session = make_session(node=simple_node,
                                test_name='TestSession.test_monitor_categories')

--- a/tests/pytests/test_session_parameters.py
+++ b/tests/pytests/test_session_parameters.py
@@ -82,7 +82,8 @@ class TestSession:
         ('timestamp', elliptics.Time(2 ** 64 - 1, 2 ** 64 - 1)),
         ('trace_id', 0),
         ('user_flags', 0)])
-    def test_properties_default(self, server, simple_node, prop, value):
+    @pytest.mark.usefixtures("servers")
+    def test_properties_default(self, simple_node, prop, value):
         session = elliptics.Session(node=simple_node)
         assert getattr(session, prop) == value
 
@@ -118,7 +119,8 @@ class TestSession:
          0,
          438975345,
          2 ** 64 - 1))])
-    def test_properties(self, server, simple_node,
+    @pytest.mark.usefixtures("servers")
+    def test_properties(self, simple_node,
                         prop, setter, getter, values):
         session = elliptics.Session(node=simple_node)
         assert type(session) == elliptics.Session
@@ -127,7 +129,8 @@ class TestSession:
                          setter=setter,
                          getter=getter)
 
-    def test_resetting_timeout(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_resetting_timeout(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_resetting_timeout')
         assert session.timeout == 5  # check default timeout value
@@ -143,13 +146,15 @@ class TestSession:
                              ('timeout', 2 ** 63),
                              ('trace_id', 2 ** 64),
                              ('user_flags', 2 ** 64)])
-    def test_properties_out_of_limits(self, server, simple_node, prop, value):
+    @pytest.mark.usefixtures("servers")
+    def test_properties_out_of_limits(self, simple_node, prop, value):
         session = elliptics.Session(simple_node)
         pytest.raises(OverflowError,
                       "set_property(session, '{0}', {1})"
                       .format(prop, value))
 
-    def test_clone(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_clone(self, simple_node):
         orig_s = make_session(node=simple_node,
                               test_name='TestSession.test_clone')
 

--- a/tests/pytests/test_session_rwr.py
+++ b/tests/pytests/test_session_rwr.py
@@ -78,7 +78,8 @@ class TestSession:
                              ('without_group_key_1', ''),
                              ('without_group_key_2', 'data'),
                              ("without_group_key_3", '309u8ryeygwvfgadd0u9g8y0ahbg8')])
-    def test_write_without_groups(self, server, simple_node, key, data):
+    @pytest.mark.usefixtures("servers")
+    def test_write_without_groups(self, simple_node, key, data):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_write_without_groups')
         result = session.write_data(key, data)
@@ -97,7 +98,8 @@ class TestSession:
                              ('all_group_key_2', 'data', None),
                              ("all_group_key_3", '309u8ryeygwvfgadd0u9g8y0ahbg8',
                               None)])
-    def test_write_to_all_groups(self, server, simple_node,
+    @pytest.mark.usefixtures("servers")
+    def test_write_to_all_groups(self, simple_node,
                                  key, data, exception):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_write_to_all_groups')
@@ -110,7 +112,8 @@ class TestSession:
         else:
             checked_write(session, key, data)
 
-    def test_write_to_one_group(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_to_one_group(self, simple_node):
         data = 'some data'
         session = make_session(node=simple_node,
                                test_name='TestSession.test_write_to_one_group')
@@ -126,7 +129,8 @@ class TestSession:
                 results = session.read_data(tmp_key).get()
                 assert results == []
 
-    def test_write_namespace(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_namespace(self, simple_node):
         key = 'namespaced_key'
         ns1 = 'namesapce 1'
         ns2 = 'namespace 2'
@@ -154,11 +158,13 @@ class TestSession:
                              ('diff key 1', 'init data', 0, 4),
                              ('diff key 1', 'rewrite data', 2, 0)
                              ])
-    def test_different_writes(self, server, simple_node,
+    @pytest.mark.usefixtures("servers")
+    def test_different_writes(self, simple_node,
                               key, data, offset, size):
         pass
 
-    def test_write_append(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_append(self, simple_node):
         key1 = 'append_key_1'
         key2 = 'append_key_2'
         data1 = 'some data 1'
@@ -182,7 +188,8 @@ class TestSession:
         checked_write(session, key2, data2)
         checked_read(session, key2, data1 + data2)
 
-    def test_bulk_write_read(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_bulk_write_read(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_bulk_write_read')
         groups = session.routes.groups()
@@ -199,7 +206,8 @@ class TestSession:
         checked_bulk_write(session, dict.fromkeys(keys, 'data'), data)
         checked_bulk_read(session, keys, data)
 
-    def test_write_cas(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_write_cas(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_write_cas')
         groups = session.routes.groups()
@@ -221,7 +229,8 @@ class TestSession:
         check_write_results(results, len(session.groups), ndata, session)
         checked_read(session, key, ndata)
 
-    def test_prepare_write_commit(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_prepare_write_commit(self, simple_node):
         session = make_session(node=simple_node,
                                test_name='TestSession.test_prepare_write_commit')
         session.groups = [session.routes.groups()[0]]
@@ -259,7 +268,8 @@ class TestSession:
 
         assert session.read_data(pos_id).get()[0].data == data
 
-    def test_prepare_plain_commit_simple(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_prepare_plain_commit_simple(self, simple_node):
         '''
         Description:
             simple write_prepare/write_plain/write_commit with checking data correctness and accessibility
@@ -302,7 +312,8 @@ class TestSession:
 
         checked_read(session, test_key, test_data)
 
-    def test_prepare_plain_commit_with_restarting_backend(self, server, simple_node):
+    @pytest.mark.usefixtures("servers")
+    def test_prepare_plain_commit_with_restarting_backend(self, simple_node):
         '''
         Description:
             write_plain/write_commit can be made if corresponding backend was restarted after write_prepare.

--- a/tests/pytests/test_session_srw.py
+++ b/tests/pytests/test_session_srw.py
@@ -29,14 +29,16 @@ class TestSession:
     #
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")
-    def test_exec_arg_event_cant_be_none(self, server, elliptics_client):
+    @pytest.mark.usefixtures("servers")
+    def test_exec_arg_event_cant_be_none(self, elliptics_client):
         elliptics_client.trace_id = make_trace_id('TestSession.test_exec_arg_event_cant_be_none')
         with pytest.raises(TypeError):
             elliptics_client.exec_('some-id', data='')
 
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")
-    def test_exec_arg_event_cant_be_missed(self, server, elliptics_client):
+    @pytest.mark.usefixtures("servers")
+    def test_exec_arg_event_cant_be_missed(self, elliptics_client):
         elliptics_client.trace_id = make_trace_id('TestSession.test_exec_arg_event_cant_be_missed')
         with pytest.raises(TypeError):
             elliptics_client.exec_('some-id', event=None, data='')
@@ -57,7 +59,8 @@ class TestSession:
 
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")
-    def test_exec_arg_id_could_be_none(self, servers, elliptics_client):
+    @pytest.mark.usefixtures("servers")
+    def test_exec_arg_id_could_be_none(self, elliptics_client):
         elliptics_client.trace_id = make_trace_id('TestSession.test_exec_arg_id_could_be_none')
         nodes = elliptics_client.routes.addresses()
         r = elliptics_client.exec_(None, event=EVENT, data='').get()
@@ -90,7 +93,7 @@ class TestSession:
             lambda x: error.append(x)
         )
         async.wait()
-        #print '%r, %r' % (results, error)
+        # print '%r, %r' % (results, error)
         assert len(error) > 0
         return results, error[0]
 
@@ -124,7 +127,8 @@ class TestSession:
     #
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")
-    def test_exec_fanout_auto(self, servers, elliptics_client, exec_func):
+    @pytest.mark.usefixtures("servers")
+    def test_exec_fanout_auto(self, elliptics_client, exec_func):
         ''' Fan out using None as id '''
         elliptics_client.trace_id = make_trace_id('TestSession.test_exec_fanout_auto')
         nodes = elliptics_client.routes.addresses()
@@ -141,12 +145,13 @@ class TestSession:
             assert r.context.address
             assert r.address == r.context.address
 
-            #TODO: check if src_id isn't empty
-            #assert r.context.src_id.id != [0] * 64
+            # TODO: check if src_id isn't empty
+            # assert r.context.src_id.id != [0] * 64
 
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")
-    def test_exec_fanout_manual(self, servers, elliptics_client, exec_func):
+    @pytest.mark.usefixtures("servers")
+    def test_exec_fanout_manual(self, elliptics_client, exec_func):
         ''' Fan out using manual lookup into routing table '''
         elliptics_client.trace_id = make_trace_id('TestSession.test_exec_fanout_manual')
         nodes = elliptics_client.routes.get_unique_routes()
@@ -164,12 +169,12 @@ class TestSession:
 
             collected.append((route.address, route.id, results[0]))
 
-        for route.address, route.id, r in collected:
+        for _, _, r in collected:
             assert r.context.address
             assert r.address == r.context.address
 
-            #TODO: check if src_id isn't empty
-            #assert r.context.src_id == id
+            # TODO: check if src_id isn't empty
+            # assert r.context.src_id == id
 
     @pytest.mark.skipif(pytest.config.option.without_cocaine,
                         reason="COCAINE wasn't specified")


### PR DESCRIPTION
Fixture `server` was renameved to `servers`. Where fixture `servers` is implicitly used it is replaces by using decorator `@pytest.mark.usefixtures("servers")`.