### PR TITLE
depends: update depends on libcocaine-dev and libcocaine-core3 to '>=0.12.8.15'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends: cdbs,
                libkora-util-dev (= 1.1.0-rc1),
                blackhole-dev (>= 1.0.0-0alpha10), blackhole-dev (<< 1.0.0-0rc1),
                blackhole-migration-dev (>= 1.0.0-0alpha10), blackhole-migration-dev (<< 1.0.0-0rc1),
-               libcocaine-dev (>= 0.12.8.11), libcocaine-dev (<< 0.12.9),
+               libcocaine-dev (>= 0.12.8.15), libcocaine-dev (<< 0.12.9),
                libcocaine-plugin-node-dev (>= 0.12.8.21), libcocaine-plugin-node-dev (<< 0.12.9),
                libcocaine-framework-native-dev (>= 0.12.8-6), libcocaine-framework-native-dev (<< 0.12.9),
 Standards-Version: 3.8.0
@@ -39,7 +39,7 @@ Depends: ${shlibs:Depends},
          elliptics-client (= ${Source-Version}),
          handystats (>= 1.11.0),
          libkora-util1 (= 1.1.0-rc1),
-         libcocaine-core3 (>= 0.12.8.11), libcocaine-core3 (<< 0.12.9),
+         libcocaine-core3 (>= 0.12.8.15), libcocaine-core3 (<< 0.12.9),
          libcocaine-plugin-node3 (>= 0.12.8.21), libcocaine-plugin-node3 (<< 0.12.9),
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
@@ -78,7 +78,7 @@ Architecture: any
 Depends: elliptics-client (= ${Source-Version})
 Suggests: eblob (>= 0.23.11),
           libkora-util1 (= 1.1.0-rc1),
-          libcocaine-core3 (>= 0.12.8.11), libcocaine-core3 (<< 0.12.9),
+          libcocaine-core3 (>= 0.12.8.15), libcocaine-core3 (<< 0.12.9),
           libcocaine-plugin-node3 (>= 0.12.8.21), libcocaine-plugin-node3 (<< 0.12.9),
           libcocaine-framework-native1 (>= 0.12.8-6), libcocaine-framework-native1 (<< 0.12.9),
 Description: Distributed hash table storage (includes)


### PR DESCRIPTION
Build with libcocaine-dev=0.12.8.11+nmu1 and libcocaine-core3=0.12.8.11+nmu1 fails on:
```
/usr/bin/ld: cannot find -lcocaine-io-util
collect2: error: ld returned 1 exit status
```