### PR TITLE
stats: update commands and top statistics for {READ,WRITE}_NEW

### DIFF
--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -97,7 +97,8 @@ write_response_t slru_cache_t::write(dnet_net_state *st, dnet_cmd *cmd, const wr
 
 		sync_after_append(guard, false, &*it);
 
-		int err = m_backend->cb->command_handler(st, m_backend->cb->command_private, cmd, request.request_data);
+		dnet_cmd_stats stats;
+		int err = m_backend->cb->command_handler(st, m_backend->cb->command_private, cmd, request.request_data, &stats);
 
 		it = populate_from_disk(guard, id, false, &err);
 

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1006,13 +1006,13 @@ static int blob_defrag_start(void *priv, enum dnet_backend_defrag_level level)
 			defrag_level = EBLOB_DEFRAG_STATE_DATA_COMPACT;
 			break;
 		default:
-			dnet_backend_log(c->blog, DNET_LOG_ERROR, "DEFRAG: unknown defragmetation level: %d", (int)level);
+			dnet_backend_log(c->blog, DNET_LOG_ERROR, "DEFRAG: unknown defragmentation level: %d", (int)level);
 			return -ENOTSUP;
 	}
 
 	int err = eblob_start_defrag_level(c->eblob, defrag_level);
 
-	dnet_backend_log(c->blog, DNET_LOG_INFO, "DEFRAG: defragmetation request: status: %d", err);
+	dnet_backend_log(c->blog, DNET_LOG_INFO, "DEFRAG: defragmentation request: status: %d", err);
 
 	return err;
 }
@@ -1197,13 +1197,13 @@ err_out_exit:
 	return err;
 }
 
-static int eblob_backend_command_handler(void *state, void *priv, struct dnet_cmd *cmd, void *data)
-{
+static int eblob_backend_command_handler(void *state, void *priv, struct dnet_cmd *cmd, void *data, void *cmd_stats) {
 	FORMATTED(HANDY_TIMER_SCOPE, ("eblob_backend.cmd.%s", dnet_cmd_string(cmd->cmd)));
 
 	int err;
 	struct eblob_backend_config *c = priv;
 
+	// TODO(shaitan): pass @cmd_stats to all blob_* functions and update statistics by them
 	switch (cmd->cmd) {
 		case DNET_CMD_LOOKUP:
 			err = blob_file_info(c, state, cmd);
@@ -1228,10 +1228,10 @@ static int eblob_backend_command_handler(void *state, void *priv, struct dnet_cm
 			err = blob_file_info_new(c, state, cmd);
 			break;
 		case DNET_CMD_READ_NEW:
-			err = blob_read_new(c, state, cmd, data);
+			err = blob_read_new(c, state, cmd, data, cmd_stats);
 			break;
 		case DNET_CMD_WRITE_NEW:
-			err = blob_write_new(c, state, cmd, data);
+			err = blob_write_new(c, state, cmd, data, cmd_stats);
 			break;
 		case DNET_CMD_ITERATOR_NEW:
 			err = blob_iterate(c, state, cmd, data);

--- a/example/eblob_backend.h
+++ b/example/eblob_backend.h
@@ -31,6 +31,7 @@ extern "C" {
 #endif
 
 struct dnet_config_backend;
+struct dnet_cmd_stats;
 
 struct eblob_read_params {
 	int			fd;
@@ -54,8 +55,10 @@ struct eblob_backend_config {
 int dnet_blob_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size);
 
 int blob_file_info_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd);
-int blob_read_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data);
-int blob_write_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data);
+int blob_read_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data,
+                  struct dnet_cmd_stats *cmd_stats);
+int blob_write_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data,
+                   struct dnet_cmd_stats *cmd_stats);
 int blob_iterate(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data);
 int blob_send_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data);
 

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -258,7 +258,8 @@ struct dnet_io_local
 
 struct dnet_backend_callbacks {
 	/* command handler processes DNET_CMD_* commands */
-	int			(* command_handler)(void *state, void *priv, struct dnet_cmd *cmd, void *data);
+	int			(* command_handler)(void *state, void *priv, struct dnet_cmd *cmd, void *data,
+	                                            void *cmd_stats);
 
 	/* this must be provided as @priv argument to all above and below callbacks*/
 	void			*command_private;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -66,6 +66,7 @@ struct dnet_test_settings;
 struct dnet_node;
 struct dnet_group;
 struct dnet_net_state;
+struct dnet_cmd_stats;
 
 extern __thread uint64_t trace_id;
 
@@ -878,9 +879,21 @@ void dnet_data_unmap(struct dnet_map_fd *map);
 
 void *dnet_cache_init(struct dnet_node *n, struct dnet_backend_io *backend, const void *config);
 void dnet_cache_cleanup(void *);
-int dnet_cmd_cache_io(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, struct dnet_io_attr *io, char *data);
-int dnet_cmd_cache_io_new(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, void *data);
-int dnet_cmd_cache_lookup(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd);
+int dnet_cmd_cache_io(struct dnet_backend_io *backend,
+                      struct dnet_net_state *st,
+                      struct dnet_cmd *cmd,
+                      struct dnet_io_attr *io,
+                      char *data,
+                      struct dnet_cmd_stats *cmd_stats);
+int dnet_cmd_cache_io_new(struct dnet_backend_io *backend,
+                          struct dnet_net_state *st,
+                          struct dnet_cmd *cmd,
+                          void *data,
+                          struct dnet_cmd_stats *cmd_stats);
+int dnet_cmd_cache_lookup(struct dnet_backend_io *backend,
+                          struct dnet_net_state *st,
+                          struct dnet_cmd *cmd,
+                          struct dnet_cmd_stats *cmd_stats);
 
 int dnet_indexes_init(struct dnet_node *, struct dnet_config *);
 void dnet_indexes_cleanup(struct dnet_node *);
@@ -1091,6 +1104,16 @@ static inline const char* dnet_print_trans(const struct dnet_trans *t) {
 	         t->wait_ts.tv_sec);
 	return __dnet_print_trans;
 }
+
+/*
+ * Statistics about handled command
+ */
+struct dnet_cmd_stats {
+	long queue_time;	// time that the command spent in queue
+	int handled_in_cache;	// whether the command handled by cache
+	long handle_time;	// time spent on the command handle
+	uint64_t size;		// size of data received or sent by command
+};
 
 
 #ifdef __cplusplus

--- a/monitor/top.cpp
+++ b/monitor/top.cpp
@@ -27,14 +27,14 @@
 namespace ioremap { namespace monitor {
 
 top_stats::top_stats(size_t top_length, size_t events_size, int period_in_seconds)
-: m_stats(events_size, period_in_seconds),
- m_top_length(top_length),
- m_period_in_seconds(period_in_seconds)
-{}
+: m_stats(events_size, period_in_seconds)
+, m_top_length(top_length)
+, m_period_in_seconds(period_in_seconds) {}
 
 void top_stats::update_stats(const struct dnet_cmd *cmd, uint64_t size)
 {
-	if (size > 0 && cmd->cmd == DNET_CMD_READ) {
+	const bool is_read = (cmd->cmd == DNET_CMD_READ) || (cmd->cmd == DNET_CMD_READ_NEW);
+	if (size > 0 && is_read) {
 		key_stat_event event(cmd->id, size, 1., time(nullptr));
 		m_stats.add_event(event, event.get_time());
 	}
@@ -46,8 +46,8 @@ top_provider::top_provider(std::shared_ptr<top_stats> top_stats)
 }
 
 static void fill_top_stat(const key_stat_event &key_event,
-                      rapidjson::Value &stat_array,
-                      rapidjson::Document::AllocatorType &allocator) {
+                          rapidjson::Value &stat_array,
+                          rapidjson::Document::AllocatorType &allocator) {
 	rapidjson::Value key_stat(rapidjson::kObjectType);
 
 	key_stat.AddMember("group", key_event.get_key()->group_id, allocator);


### PR DESCRIPTION
Add `dnet_cmd_stats` which will be pass to all handlers to collect statistics about command handling like: time spent by the command in queue, wheather the command was handled by cache, time spent on command handling and size of command's data (for read - size of read data, for write - size of written data, for others - 0).

Add sending to commands and top statistics info about handling READ_NEW and WRITE_NEW.