### PR TITLE
Cocaine component registration

### DIFF
--- a/cocaine/include/cocaine/api/elliptics_node.hpp
+++ b/cocaine/include/cocaine/api/elliptics_node.hpp
@@ -1,0 +1,46 @@
+#ifndef COCAINE_API_ELLIPTICS_NODE
+#define COCAINE_API_ELLIPTICS_NODE
+
+#include <cocaine/repository.hpp>
+
+namespace cocaine { namespace api {
+
+struct elliptics_node_t;
+
+/**
+ * Traits for local elliptics node component.
+ * Factory is statefull and always returns the same assigned in node, assigned in ctor
+ */
+template<>
+struct category_traits<elliptics_node_t> {
+	typedef dnet_node* ptr_type;
+
+	struct factory_type: public basic_factory<elliptics_node_t> {
+		virtual ptr_type get() = 0;
+	};
+
+	template<class T>
+	struct default_factory: public factory_type {
+		default_factory(dnet_node* _n)
+		: n(_n) { }
+
+		virtual dnet_node* get() {
+			return n;
+		}
+	private:
+		dnet_node *n;
+	};
+};
+
+
+// This one is only component category tag.
+// Real type of the elliptics_node_t component is dnet_node*
+struct elliptics_node_t {
+	typedef elliptics_node_t category_type;
+	typedef category_traits<elliptics_node_t>::default_factory<elliptics_node_t> factory_t;
+};
+
+} // namespace api
+} // namespace cocaine
+
+#endif

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends: cdbs,
                libkora-util-dev (= 1.1.0-rc1),
                blackhole-dev (>= 1.0.0-0rc1),
                blackhole-migration-dev (>= 1.0.0-0rc1),
-               libcocaine-dev (>= 0.12.9), libcocaine-dev (<< 0.12.10),
+               libcocaine-dev (>= 0.12.9.0-alpha5), libcocaine-dev (<< 0.12.10),
                libcocaine-plugin-node-dev (>= 0.12.9), libcocaine-plugin-node-dev (<< 0.12.10),
                libcocaine-framework-native-dev (>= 0.12.9), libcocaine-framework-native-dev (<< 0.12.10),
 Standards-Version: 3.8.0
@@ -39,7 +39,7 @@ Depends: ${shlibs:Depends},
          elliptics-client (= ${Source-Version}),
          handystats (>= 1.11.0),
          libkora-util1 (= 1.1.0-rc1),
-         libcocaine-core3 (>= 0.12.9), libcocaine-core3 (<< 0.12.10),
+         libcocaine-core3 (>= 0.12.9.0-alpha5), libcocaine-core3 (<< 0.12.10),
          libcocaine-plugin-node3 (>= 0.12.9), libcocaine-plugin-node3 (<< 0.12.10),
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
@@ -79,7 +79,7 @@ Architecture: any
 Depends: elliptics-client (= ${Source-Version})
 Suggests: eblob (>= 0.23.11),
           libkora-util1 (= 1.1.0-rc1),
-          libcocaine-core3 (>= 0.12.9), libcocaine-core3 (<< 0.12.10),
+          libcocaine-core3 (>= 0.12.9.0-alpha5), libcocaine-core3 (<< 0.12.10),
           libcocaine-plugin-node3 (>= 0.12.9), libcocaine-plugin-node3 (<< 0.12.10),
           libcocaine-framework-native1 (>= 0.12.9), libcocaine-framework-native1 (<< 0.12.10),
 Description: Distributed hash table storage (includes)

--- a/srw/localnode.cpp
+++ b/srw/localnode.cpp
@@ -25,6 +25,7 @@
 #include <cocaine/rpc/actor.hpp> // for factory
 #include <cocaine/logging.hpp>
 
+#include "cocaine/api/elliptics_node.hpp"
 #include "cocaine/idl/localnode.hpp"
 #include "cocaine/traits/localnode.hpp"
 #include "localnode.hpp"
@@ -66,10 +67,11 @@ std::vector<int> find_local_groups(dnet_node *node)
 }
 
 localnode::localnode(cocaine::context_t &context, asio::io_service &reactor, const std::string &name,
-                     const cocaine::dynamic_t &args, dnet_node *node)
+                     const cocaine::dynamic_t &args)
 : cocaine::api::service_t(context, reactor, name, args)
 , cocaine::dispatch<io::localnode_tag>(name)
-, m_session_proto(node)
+, m_node(context.repository().get<cocaine::api::elliptics_node_t>("elliptics_node"))
+, m_session_proto(m_node)
 , m_log(context.log(name)) {
 	COCAINE_LOG_DEBUG(m_log, "{}: ENTER", __func__);
 
@@ -83,7 +85,7 @@ localnode::localnode(cocaine::context_t &context, asio::io_service &reactor, con
 	{
 		// We are forced to find all local groups anyway because there is no other
 		// way to get the total number of the groups this node serves.
-		const auto local_groups = find_local_groups(node);
+		const auto local_groups = find_local_groups(m_node);
 		COCAINE_LOG_INFO(m_log, "{}: found local groups: [{}]", __func__, to_string(local_groups).c_str());
 		if (local_groups.size() == 1) {
 			m_session_proto.set_groups(local_groups);

--- a/srw/localnode.hpp
+++ b/srw/localnode.hpp
@@ -35,7 +35,7 @@ class localnode : public cocaine::api::service_t, public cocaine::dispatch<io::l
 {
 public:
 	localnode(cocaine::context_t &context, asio::io_service &reactor, const std::string &name,
-	          const cocaine::dynamic_t &args, dnet_node *node);
+	          const cocaine::dynamic_t &args);
 
 	// service_t interface
 	const cocaine::io::basic_dispatch_t &prototype() const { return *this; }
@@ -59,6 +59,7 @@ private:
 	);
 
 private:
+	dnet_node* m_node;
 	newapi::session m_session_proto;
 	std::shared_ptr<cocaine::logging::logger_t> m_log;
 };

--- a/tests/cocaine.conf
+++ b/tests/cocaine.conf
@@ -36,6 +36,10 @@
             "args": {
                 "runlist": ""
             }
+        },
+        "localnode": {
+            "type": "localnode",
+            "args" : {}
         }
     },
 


### PR DESCRIPTION
Adapt to new possibility of cocaine to register new components.
This is required for upcoming storage accessor service, also localnode initialization is now made via config as a common service. Bound to https://github.com/3Hren/cocaine-core/pull/97