### PR TITLE
forward: add ability to set forward node in session

### DIFF
--- a/bindings/cpp/newapi/session.cpp
+++ b/bindings/cpp/newapi/session.cpp
@@ -296,6 +296,9 @@ async_read_result session::read_json(const key &id) {
 	request.ioflags = get_ioflags();
 	request.read_flags = DNET_READ_FLAGS_JSON;
 
+	dnet_current_time(&request.deadline);
+	request.deadline.tsec += get_timeout();
+
 	return send_read(*this, id, request, std::move(groups));
 }
 
@@ -311,6 +314,9 @@ async_read_result session::read_data(const key &id, uint64_t offset, uint64_t si
 	request.data_offset = offset;
 	request.data_size = size;
 
+	dnet_current_time(&request.deadline);
+	request.deadline.tsec += get_timeout();
+
 	return send_read(*this, id, request, std::move(groups));
 }
 
@@ -325,6 +331,9 @@ async_read_result session::read(const key &id, uint64_t offset, uint64_t size) {
 	request.read_flags = DNET_READ_FLAGS_JSON | DNET_READ_FLAGS_DATA;
 	request.data_offset = offset;
 	request.data_size = size;
+
+	dnet_current_time(&request.deadline);
+	request.deadline.tsec += get_timeout();
 
 	return send_read(*this, id, request, std::move(groups));
 }
@@ -489,6 +498,9 @@ static dnet_write_request create_write_request(const session &sess)
 	if (dnet_time_is_empty(&request.json_timestamp)) {
 		request.json_timestamp = request.timestamp;
 	}
+
+	dnet_current_time(&request.deadline);
+	request.deadline.tsec += sess.get_timeout();
 
 	return request;
 }

--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -205,6 +205,23 @@ public:
 		}
 	}
 
+	void set_forward(const bp::api::object &remote) {
+		if (remote.ptr() != Py_None) {
+			bp::extract<std::string> get_remote(remote);
+			session::set_forward(address(get_remote()));
+		} else {
+			session::reset_forward();
+		}
+	}
+
+	bp::api::object get_forward() {
+		if (session::get_cflags() & DNET_FLAGS_FORWARD) {
+			return bp::object(session::get_forward().to_string_with_family());
+		}
+
+		return bp::object();
+	}
+
 	struct elliptics_id get_direct_id() {
 		return session::get_direct_id();
 	}
@@ -1110,6 +1127,19 @@ void init_elliptics_session() {
 		    "get_direct_id()\n"
 		    "    Returns elliptics.Id of current direct node\n\n"
 		    "    id = session.get_direct_id()")
+
+		.add_property("forward",
+		              &elliptics_session::get_forward,
+		              &elliptics_session::set_forward,
+		              "Stick session to particular remote address.\n"
+		              "This remote won't handle request but will resend it to proper server node.\n"
+		              "If proper server node isn't available on forward node, forward node will fail\n"
+		              "request with -ENOTSUP error.\n\n"
+		              "# set forward\n"
+		              "session.forward = elliptics.Address.from_host_port_family(host='host.com', port=1025, family=AF_INET)\n"
+		              "print session.forward\n"
+		              "session.forward = None  # reset forward\n"
+		              "del session.forward  # reset forward")
 
 		.add_property("exceptions_policy",
 		              &elliptics_session::get_exceptions_policy,

--- a/bindings/python/src/newapi.py
+++ b/bindings/python/src/newapi.py
@@ -22,6 +22,7 @@ import elliptics.core
 @logged_class
 class Session(elliptics.core.newapi.Session):
     """New elliptics session interface."""
+    __forward = elliptics.core.newapi.Session.forward
 
     def __init__(self, node):
         """
@@ -162,6 +163,25 @@ class Session(elliptics.core.newapi.Session):
                                                port=address.port,
                                                family=address.family,
                                                backend_id=backend_id)
+
+    @property
+    def forward(self):
+        """
+        If is set stick session to particular remote address.
+        This remote won't handle request but will resend it to proper server node.
+        If proper server node isn't available on forward node, forward node will fail request with -ENOTSUP error.
+        """
+        if self.__forward is None:
+            return None
+        return Address.from_host_port_family(self.__forward)
+
+    @forward.setter
+    def forward(self, remote):
+        self.__forward = None if remote is None else str(remote)
+
+    @forward.deleter
+    def forward(self):
+        self.__forward = None
 
     def update_status(self, address, status):
         """

--- a/bindings/python/src/session.py
+++ b/bindings/python/src/session.py
@@ -20,6 +20,8 @@ from elliptics.log import logged_class
 
 @logged_class
 class Session(Session):
+    __forward = Session.forward
+
     def __init__(self, node):
         '''
         Initializes session by the node"
@@ -32,7 +34,7 @@ class Session(Session):
     def clone(self):
         '''
         Creates and returns session which is equal to current"
-        but complitely independent from it."
+        but completely independent from it."
 
         cloned_session = session.clone()
         '''
@@ -97,7 +99,7 @@ class Session(Session):
 
     def update_indexes(self, id, indexes, datas=None):
         """
-        Adds id to additional indees and or updates data for the id in specified indexes.
+        Adds id to additional indexes and or updates data for the id in specified indexes.
         Also it updates list of indexes where id is.
         Return elliptics.AsyncResult.
         -- id - string or elliptics.Id
@@ -125,7 +127,7 @@ class Session(Session):
 
     def update_indexes_internal(self, id, indexes, datas=None):
         """
-        Adds id to additional indees and or updates data for the id in specified indexes.
+        Adds id to additional indexes and or updates data for the id in specified indexes.
         It doesn't update list of indexes where id is.
         Return elliptics.AsyncResult.
         -- id - string or elliptics.Id
@@ -166,6 +168,25 @@ class Session(Session):
                                                port=address.port,
                                                family=address.family,
                                                backend_id=backend_id)
+
+    @property
+    def forward(self):
+        """
+        If is set stick session to particular remote address.
+        This remote won't handle request but will resend it to proper server node.
+        If proper server node isn't available on forward node, forward node will fail request with -ENOTSUP error.
+        """
+        if self.__forward is None:
+            return None
+        return Address.from_host_port_family(self.__forward)
+
+    @forward.setter
+    def forward(self, remote):
+        self.__forward = None if remote is None else str(remote)
+
+    @forward.deleter
+    def forward(self):
+        self.__forward = None
 
     def update_status(self, address, status):
         """

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -428,6 +428,9 @@ void dnet_session_set_direct_addr(struct dnet_session *s, const struct dnet_addr
 uint32_t dnet_session_get_direct_backend(struct dnet_session *s);
 void dnet_session_set_direct_backend(struct dnet_session *s, uint32_t backend_id);
 
+void dnet_session_set_forward(struct dnet_session *s, const struct dnet_addr *addr);
+const struct dnet_addr *dnet_session_get_forward(const struct dnet_session *s);
+
 void dnet_session_set_user_flags(struct dnet_session *s, uint64_t user_flags);
 uint64_t dnet_session_get_user_flags(struct dnet_session *s);
 

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -186,6 +186,9 @@ enum dnet_backend_defrag_level {
 /* Do not use queue timeout for the request */
 #define DNET_FLAGS_NO_QUEUE_TIMEOUT	(1<<10)
 
+/* Send this request to forward node which should resend it to proper node */
+#define DNET_FLAGS_FORWARD		(1<<11)
+
 struct flag_info
 {
 	uint64_t flag;
@@ -235,6 +238,7 @@ static inline const char *dnet_flags_dump_cflags(uint64_t flags)
 		{ DNET_FLAGS_TRACE_BIT, "tracebit" },
 		{ DNET_FLAGS_REPLY, "reply" },
 		{ DNET_FLAGS_NO_QUEUE_TIMEOUT, "no_queue_timeout"},
+		{ DNET_FLAGS_FORWARD, "forward"}
 	};
 
 	dnet_flags_dump_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));

--- a/include/elliptics/session.hpp
+++ b/include/elliptics/session.hpp
@@ -333,6 +333,17 @@ class session
 		 */
 		void set_direct_id(const address &remote_addr);
 		void set_direct_id(const address &remote_addr, uint32_t backend_id);
+		void reset_direct_id();
+
+		/*!
+		 * Stick session to particular remote address.
+		 * This remote won't handle request but will resend it to proper server node.
+		 * If proper server node isn't available on forward node, forward node will fail
+		 * request with -ENOTSUP error.
+		 */
+		void set_forward(const address &remote);
+		address get_forward() const;
+		void reset_forward();
 
 		/*!
 		 * Gets command flags of the session.
@@ -1016,6 +1027,7 @@ class session
 		 * Returns pointer to dnet_session.
 		 */
 		dnet_session *get_native();
+		const dnet_session *get_native() const;
 
 	protected:
 		std::shared_ptr<session_data> m_data;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -695,6 +695,12 @@ struct dnet_session {
 	struct dnet_addr	direct_addr;
 	int			direct_backend;
 
+	/*
+	 * If DNET_FLAGS_FORWARD is set then forward_addr is used for sticking
+	 * requests to the node.
+	 */
+	struct dnet_addr	forward_addr;
+
 	/* Namespace */
 	char			*ns;
 	int			nsize;
@@ -836,6 +842,8 @@ int dnet_trans_iterate_move_transaction(struct dnet_net_state *st, struct list_h
 int dnet_state_reset_nolock_noclean(struct dnet_net_state *st, int error, struct list_head *head);
 
 int dnet_trans_send(struct dnet_trans *t, struct dnet_io_req *req);
+
+int dnet_trans_forward(struct dnet_io_req *r, struct dnet_net_state *orig, struct dnet_net_state *forward);
 
 int dnet_recv_list(struct dnet_node *n, struct dnet_net_state *st);
 

--- a/library/node.c
+++ b/library/node.c
@@ -912,6 +912,7 @@ struct dnet_session *dnet_session_copy(struct dnet_session *s)
 	new_s->user_flags = s->user_flags;
 	new_s->direct_addr = s->direct_addr;
 	new_s->direct_backend = s->direct_backend;
+	new_s->forward_addr = s->forward_addr;
 
 	if (s->group_num > 0) {
 		err = dnet_session_set_groups(new_s, s->groups, s->group_num);
@@ -1139,4 +1140,12 @@ uint32_t dnet_session_get_direct_backend(struct dnet_session *s)
 void dnet_session_set_direct_backend(struct dnet_session *s, uint32_t backend_id)
 {
 	s->direct_backend = backend_id;
+}
+
+void dnet_session_set_forward(struct dnet_session *s, const struct dnet_addr *addr) {
+	s->forward_addr = *addr;
+}
+
+const struct dnet_addr *dnet_session_get_forward(const struct dnet_session *s) {
+	return &s->forward_addr;
 }

--- a/library/protocol.cpp
+++ b/library/protocol.cpp
@@ -37,16 +37,24 @@ inline dnet_read_request &operator >>(msgpack::object o, dnet_read_request &v) {
 	p[2].convert(&v.data_offset);
 	p[3].convert(&v.data_size);
 
+	if (o.via.array.size > 4) {
+		p[4].convert(&v.deadline);
+	} else {
+		// for older protocol
+		dnet_empty_time(&v.deadline);
+	}
+
 	return v;
 }
 
 template <typename Stream>
 inline msgpack::packer<Stream> &operator <<(msgpack::packer<Stream> &o, const dnet_read_request &v) {
-	o.pack_array(4);
+	o.pack_array(5);
 	o.pack(v.ioflags);
 	o.pack(v.read_flags);
 	o.pack(v.data_offset);
 	o.pack(v.data_size);
+	o.pack(v.deadline);
 
 	return o;
 }
@@ -125,12 +133,19 @@ inline dnet_write_request &operator >>(msgpack::object o, dnet_write_request &v)
 		v.cache_lifetime = 0;
 	}
 
+	if (o.via.array.size > 11) {
+		p[11].convert(&v.deadline);
+	} else {
+		// for older protocol
+		dnet_empty_time(&v.deadline);
+	}
+
 	return v;
 }
 
 template <typename Stream>
 inline msgpack::packer<Stream> &operator <<(msgpack::packer<Stream> &o, const dnet_write_request &v) {
-	o.pack_array(11);
+	o.pack_array(12);
 	o.pack(v.ioflags);
 	o.pack(v.user_flags);
 
@@ -145,7 +160,10 @@ inline msgpack::packer<Stream> &operator <<(msgpack::packer<Stream> &o, const dn
 	o.pack(v.data_commit_size);
 
 	o.pack(v.json_timestamp);
+
 	o.pack(v.cache_lifetime);
+
+	o.pack(v.deadline);
 
 	return o;
 }

--- a/library/protocol.hpp
+++ b/library/protocol.hpp
@@ -27,6 +27,8 @@ struct dnet_read_request {
 	uint64_t read_flags;
 	uint64_t data_offset;
 	uint64_t data_size;
+
+	dnet_time deadline;
 };
 
 struct dnet_read_response {
@@ -59,6 +61,8 @@ struct dnet_write_request {
 	uint64_t data_commit_size;
 
 	uint64_t cache_lifetime;
+
+	dnet_time deadline;
 };
 
 struct dnet_lookup_response {

--- a/library/trans.c
+++ b/library/trans.c
@@ -428,15 +428,19 @@ int dnet_trans_alloc_send(struct dnet_session *s, struct dnet_trans_control *ctl
 	if (dnet_session_get_cflags(s) & DNET_FLAGS_DIRECT) {
 		st = dnet_state_search_by_addr(n, &s->direct_addr);
 		addr = &s->direct_addr;
-	} else {
+	} else if(dnet_session_get_cflags(s) & DNET_FLAGS_FORWARD) {
+		st = dnet_state_search_by_addr(n, &s->forward_addr);
+		addr = &s->forward_addr;
+	}else {
 		st = dnet_state_get_first(n, &ctl->id);
 	}
 
 	if (!st) {
 		err = -ENXIO;
-		dnet_log(n, DNET_LOG_ERROR, "%s: direct: %d, direct-addr: %s: trans_send: could not find network state for address",
+		dnet_log(n, DNET_LOG_ERROR, "%s: direct: %d, direct-addr: %s, forward: %d: trans_send: could not find network state for address",
 			dnet_dump_id(&ctl->id),
-			!!(dnet_session_get_cflags(s) & DNET_FLAGS_DIRECT), dnet_addr_string(&s->direct_addr));
+			!!(dnet_session_get_cflags(s) & DNET_FLAGS_DIRECT), dnet_addr_string(&s->direct_addr),
+			!!(dnet_session_get_cflags(s) & DNET_FLAGS_FORWARD));
 
 		err = dnet_trans_send_fail(s, addr, ctl, -ENXIO, 1);
 	} else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,7 +169,7 @@ add_test_target(test_locks dnet_locks_test DEPENDS ${TESTS_DEPS})
 
 add_executable(dnet_crypto_test crypto_test.cpp)
 set_target_properties(dnet_crypto_test ${TEST_PROPERTIES})
-target_link_libraries(dnet_crypto_test ${TEST_LIBRARIES})
+target_link_libraries(dnet_crypto_test elliptics)
 add_test_target(test_crypto dnet_crypto_test DEPENDS ${TESTS_DEPS})
 
 add_executable(dnet_server_send_test server_send.cpp)
@@ -204,6 +204,11 @@ set_target_properties(dnet_new_api_server_send_test ${TEST_PROPERTIES})
 target_link_libraries(dnet_new_api_server_send_test ${TEST_LIBRARIES})
 add_test_target(test_new_api_server_send dnet_new_api_server_send_test DEPENDS ${TESTS_DEPS})
 
+add_executable(dnet_forwarding_test forwarding_test.cpp)
+set_target_properties(dnet_forwarding_test ${TEST_PROPERTIES})
+target_link_libraries(dnet_forwarding_test ${TEST_LIBRARIES})
+add_test_target(test_forwarding dnet_forwarding_test DEPENDS ${TESTS_DEPS})
+
 #
 # General list of test modules (implemented in C++).
 #
@@ -221,6 +226,8 @@ set(TESTS_LIST
     dnet_server_send_test
     dnet_queue_timeout_test
     dnet_new_api_test
+    dnet_new_api_server_send_test
+    dnet_forwarding_test
 )
 
 if(WITH_COCAINE)

--- a/tests/forwarding_test.cpp
+++ b/tests/forwarding_test.cpp
@@ -1,0 +1,199 @@
+#include <boost/program_options.hpp>
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+#include <boost/test/included/unit_test.hpp>
+
+#include "test_base.hpp"
+
+namespace tests {
+namespace bu = boost::unit_test;
+
+nodes_data::ptr configure_test_setup(const std::string &path) {
+	constexpr auto server_config = [](const config_data &c) {
+		auto server = server_config::default_value();
+		server.options("wait_timeout", 3);
+		return server.apply_options(c);
+	};
+
+	auto configs = {server_config(config_data()("group", 1)),
+	                server_config(config_data()("group", 2)),
+	                server_config(config_data()("group", 3))};
+
+	start_nodes_config config{bu::results_reporter::get_stream(), configs, path};
+	config.fork = true;
+
+	return start_nodes(config);
+}
+
+void test_forward_lookup(ioremap::elliptics::newapi::session &session, const nodes_data *setup) {
+	auto s = session.clone();
+	s.set_groups({1, 2, 3});
+	s.set_filter(ioremap::elliptics::filters::all_final);
+
+	const auto forward = setup->nodes.front().remote();
+	s.set_forward(forward);
+
+	auto async = s.lookup({"nonexistent key"});
+
+	size_t count = 0;
+	for (const auto &result: async) {
+		BOOST_REQUIRE_EQUAL(result.status(), -ENOENT);
+		std::string forward_address = "";
+		BOOST_REQUIRE_EQUAL(dnet_addr_string(result.address()), forward.to_string());
+		++count;
+	}
+	BOOST_REQUIRE_EQUAL(count, 3);
+}
+
+void test_forward_lookup_2_nothing(ioremap::elliptics::newapi::session &session) {
+	auto s = session.clone();
+	s.set_groups({1, 2, 3});
+	s.set_filter(ioremap::elliptics::filters::all_final);
+
+	s.set_forward(ioremap::elliptics::address());
+
+	auto async = s.lookup({"nonexistent key"});
+
+	size_t count = 0;
+	for (const auto &result: async) {
+		BOOST_REQUIRE_EQUAL(result.status(), -ENXIO);
+		++count;
+	}
+	BOOST_REQUIRE_EQUAL(count, 3);
+}
+
+void test_forward_lookup_2_nonexistent_groups(ioremap::elliptics::newapi::session &session, const nodes_data *setup) {
+	auto s = session.clone();
+	s.set_groups({5, 6, 7});
+	s.set_filter(ioremap::elliptics::filters::all_final);
+
+	const auto forward = setup->nodes.front().remote();
+	s.set_forward(forward);
+
+	auto async = s.lookup({"nonexistent key"});
+
+	size_t count = 0;
+	for (const auto &result: async) {
+		BOOST_REQUIRE_EQUAL(result.status(), -ENOTSUP);
+		BOOST_REQUIRE_EQUAL(dnet_addr_string(result.address()), forward.to_string());
+		++count;
+	}
+	BOOST_REQUIRE_EQUAL(count, 3);
+}
+
+void test_forward_read_with_deadline(ioremap::elliptics::newapi::session &session, const nodes_data *setup) {
+	auto s = session.clone();
+	s.set_groups({2});
+	s.set_filter(ioremap::elliptics::filters::all_final);
+
+	const auto delayed_remote = setup->nodes[1].remote();
+	static const auto delayed_backend = 0;
+	s.set_delay(delayed_remote, delayed_backend, 3000).wait();
+
+	s.set_timeout(1);
+	const auto forward = setup->nodes.front().remote();
+	s.set_forward(forward);
+
+	{
+		auto async = s.lookup({"nonexistent key"});
+		size_t count = 0;
+		for (const auto &result: async) {
+			BOOST_REQUIRE_EQUAL(result.status(), -ETIMEDOUT);
+			// lookup doesn't currently support deadlines, so it should be client's timeout,
+			// and result shouldn't contain DNET_FLAGS_REPLY flag.
+			BOOST_REQUIRE(!(result.command()->flags & DNET_FLAGS_REPLY));
+			BOOST_REQUIRE_EQUAL(dnet_addr_string(result.address()), forward.to_string());
+			++count;
+		}
+		BOOST_REQUIRE_EQUAL(count, 1);
+	}
+
+	{
+		auto async = s.read_json({"nonexistent key"});
+		size_t count = 0;
+		for (const auto &result: async) {
+			BOOST_REQUIRE_EQUAL(result.status(), -ETIMEDOUT);
+			// read supports deadlines, so it should be forward node's timeout,
+			// and result should contain DNET_FLAGS_REPLY flag.
+			BOOST_REQUIRE(result.command()->flags & DNET_FLAGS_REPLY);
+			BOOST_REQUIRE_EQUAL(dnet_addr_string(result.address()), forward.to_string());
+			++count;
+		}
+		BOOST_REQUIRE_EQUAL(count, 1);
+	}
+
+	{
+		auto async = s.write({"test_forward_read_with_deadline: some key"}, "", 0, "some data", 0);
+		size_t count = 0;
+		for (const auto &result: async) {
+			BOOST_REQUIRE_EQUAL(result.status(), -ETIMEDOUT);
+			// write supports deadlines, so it should be forward node's timeout,
+			// and result should contain DNET_FLAGS_REPLY flag.
+			BOOST_REQUIRE(result.command()->flags & DNET_FLAGS_REPLY);
+			BOOST_REQUIRE_EQUAL(dnet_addr_string(result.address()), forward.to_string());
+			++count;
+		}
+		BOOST_REQUIRE_EQUAL(count, 1);
+	}
+
+	// reset backend's delay to 0
+	s.set_delay(delayed_remote, delayed_backend, 0).wait();
+}
+
+bool register_tests(const nodes_data *setup)
+{
+	auto n = setup->node->get_native();
+
+	ELLIPTICS_TEST_CASE(test_forward_lookup, use_session(n), setup);
+	ELLIPTICS_TEST_CASE(test_forward_lookup_2_nothing, use_session(n));
+	ELLIPTICS_TEST_CASE(test_forward_lookup_2_nonexistent_groups, use_session(n), setup);
+	ELLIPTICS_TEST_CASE(test_forward_read_with_deadline, use_session(n), setup);
+
+	return true;
+}
+
+nodes_data::ptr configure_test_setup_from_args(int argc, char *argv[]) {
+	namespace bpo = boost::program_options;
+
+	bpo::variables_map vm;
+	bpo::options_description generic("Test options");
+
+	std::string path;
+
+	generic.add_options()
+		("help", "This help message")
+		("path", bpo::value(&path), "Path where to store everything")
+		;
+
+	bpo::store(bpo::parse_command_line(argc, argv, generic), vm);
+	bpo::notify(vm);
+
+	if (vm.count("help")) {
+		std::cerr << generic;
+		return nullptr;
+	}
+
+	return tests::configure_test_setup(path);
+}
+
+} /* namespace tests */
+
+namespace {
+std::shared_ptr<tests::nodes_data> setup;
+
+bool init_func() {
+	return tests::register_tests(setup.get());
+}
+
+} /* namespace */
+
+int main(int argc, char *argv[]) {
+	srand(time(nullptr));
+
+	setup = tests::configure_test_setup_from_args(argc, argv);
+	int result = boost::unit_test::unit_test_main(init_func, argc, argv);
+	setup.reset();
+
+	return result;
+}


### PR DESCRIPTION
All read, write, lookup and remove requests will be sent to the forward node which
in turn resend them to proper node if they are connected.