### PR TITLE
localnode: methods accept flags

### DIFF
--- a/cocaine/include/cocaine/idl/localnode.hpp
+++ b/cocaine/include/cocaine/idl/localnode.hpp
@@ -40,7 +40,11 @@ struct localnode {
 			/* Offset */
 			uint64_t,
 			/* Size */
-			uint64_t
+			uint64_t,
+			/* Command flags */
+			cocaine::io::optional<uint64_t>,
+			/* I/O related flags */
+			cocaine::io::optional<uint32_t>
 		> argument_type;
 
 		typedef cocaine::io::option_of<
@@ -62,7 +66,11 @@ struct localnode {
 			/* Writing group list */
 			std::vector<int>,
 			/* Raw bytes of the value */
-			std::string
+			std::string,
+			/* Command flags */
+			cocaine::io::optional<uint64_t>,
+			/* I/O related flags */
+			cocaine::io::optional<uint32_t>
 		> argument_type;
 
 		typedef cocaine::io::option_of<
@@ -82,7 +90,9 @@ struct localnode {
 			/* Elliptics id */
 			dnet_raw_id,
 			/* Reading group list */
-			std::vector<int>
+			std::vector<int>,
+			/* Command flags */
+			cocaine::io::optional<uint64_t>
 		> argument_type;
 
 		typedef cocaine::io::option_of<

--- a/srw/localnode.hpp
+++ b/srw/localnode.hpp
@@ -45,9 +45,9 @@ private:
 	typedef std::tuple<dnet_record_info, std::string> lookup_result;
 	typedef lookup_result write_result;
 
-	deferred<read_result> read(const dnet_raw_id &key, const std::vector<int> &groups, uint64_t offset, uint64_t size);
-	deferred<lookup_result> lookup(const dnet_raw_id &key, const std::vector<int> &groups);
-	deferred<write_result> write(const dnet_raw_id &key, const std::vector<int> &groups, const std::string &bytes);
+	deferred<read_result> read(const dnet_raw_id &key, const std::vector<int> &groups, uint64_t offset, uint64_t size, uint64_t cflags, uint32_t ioflags);
+	deferred<lookup_result> lookup(const dnet_raw_id &key, const std::vector<int> &groups, uint64_t cflags);
+	deferred<write_result> write(const dnet_raw_id &key, const std::vector<int> &groups, const std::string &bytes, uint64_t cflags, uint32_t ioflags);
 
 	void on_read_completed(deferred<read_result> promise,
 		const std::vector<newapi::read_result_entry> &results,

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -531,6 +531,31 @@ static void test_localnode(session &client, const std::vector<int> &groups, int 
 #undef CMP
 
 	BOOST_CHECK_EQUAL(std::get<1>(read_result).to_string(), value);
+
+	// check if methods could take flags
+	{
+		auto future = localnode.invoke<io::localnode::write>(key.raw_id(), groups, value,
+			DNET_FLAGS_NOLOCK,
+			DNET_IO_FLAGS_CACHE_ONLY
+		);
+		BOOST_REQUIRE_EQUAL(future.valid(), true);
+		BOOST_REQUIRE_NO_THROW(future.get());
+	}
+	{
+		auto future = localnode.invoke<io::localnode::lookup>(key.raw_id(), groups,
+			DNET_FLAGS_NOLOCK
+		);
+		BOOST_REQUIRE_EQUAL(future.valid(), true);
+		BOOST_REQUIRE_NO_THROW(future.get());
+	}
+	{
+		auto future = localnode.invoke<io::localnode::read>(key.raw_id(), groups, 0, 0,
+			DNET_FLAGS_NOLOCK,
+			DNET_IO_FLAGS_CACHE | DNET_IO_FLAGS_NOCSUM
+		);
+		BOOST_REQUIRE_EQUAL(future.valid(), true);
+		BOOST_REQUIRE_NO_THROW(future.get());
+	}
 }
 
 


### PR DESCRIPTION
localnode is of the same logical level as elliptics session, they are equally low-level. Only the user of localnode (and/or session) could know the required execution mode of the commands and specifics of the required I/O, hence only the user could specify proper set of command and/or I/O flags.
Session class have `set_{c,io}flags` methods for that -- so localnode methods must accept `{c,io}flags` parameters.

Note flags whitelisting -- we don't want to give the user an unbounded freedom here (some of the {c,io}flags are really for elliptics internal use only, some are dangerous, and some just don't have sense or meaning in the context of localnode).