### PR TITLE
Localnode and srw tracing

### DIFF
--- a/srw/CMakeLists.txt
+++ b/srw/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(elliptics_srw
     ${MSGPACK_LIBRARIES}
     ${COCAINE_NODE_SERVICE_LIBRARIES}
 
-    #FIXME: should add it properly
+    #FIXME: should add them properly
     cocaine-io-util
     blackhole
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,7 +255,7 @@ if(WITH_COCAINE)
         elliptics_cpp
         ${Boost_LIBRARIES}
         ${CocaineNative_LIBRARIES}
-        #FIXME: should add it properly
+        #FIXME: should add them properly
         cocaine-io-util
         blackhole
     )

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -472,6 +472,13 @@ static void test_localnode(session &client, const std::vector<int> &groups, int 
 	service_manager_t::endpoint_type endpoint(boost::asio::ip::address_v4::loopback(), locator_port);
 	service_manager_t manager({endpoint}, 1);
 
+	cocaine::trace_t::current() = cocaine::trace_t(
+		// trace
+		client.get_trace_id(), client.get_trace_id(), cocaine::trace_t::zero_value,
+		// rpc_name
+		"srw_test"
+	);
+
 	auto localnode = manager.create<io::localnode_tag>("localnode");
 
 	key key(gen_random(8));

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -574,7 +574,7 @@ bool register_tests(const nodes_data *setup)
 	auto n = setup->node->get_native();
 
 	/* prerequisite: launch and init test application
-	 *TODO: turn them collectively to fixture
+	 * TODO: turn them collectively into some fixture
 	 */
 	ELLIPTICS_TEST_CASE(upload_application, setup->nodes[0].locator_port(), app, setup->directory.path());
 	for (const auto &i : setup->nodes) {

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -79,6 +79,8 @@ void test_wrapper_with_session::operator() () const
 
 	newapi::session client(n);
 
+	//XXX: make trace_id to be not random but derived from test case?
+	// (md5 over test_name and session args)
 	uint64_t trace_id = 0;
 	auto buffer = reinterpret_cast<unsigned char *>(&trace_id);
 	for (size_t i = 0; i < sizeof(trace_id); ++i) {


### PR DESCRIPTION
Adds tracing support at all places where request execution goes from elliptics to cocaine or from cocaine to elliptics.

There are still problems but we consider them temporary:
1) trace_id conversion from hex string to int64 in logger_adapter
2) not an optimal behavior due to differences in tracing logic between elliptics and cocaine (cocaine considers presence of trace as elliptics considers presence of trace+tracebit)

First should be alleviated by making cocaine switch to keep trace_id log attribute as integer (should happen soon).