### PR TITLE
update to blackhole v1.2.1

### DIFF
--- a/bindings/cpp/logger.cpp
+++ b/bindings/cpp/logger.cpp
@@ -65,7 +65,7 @@ bool log_filter(const blackhole::record_t &record, int level) {
 
 std::unique_ptr<dnet_logger> make_file_logger(const std::string &path, dnet_log_level level) {
 	static const std::string pattern =
-	        "{timestamp} {trace_id:{0:default}0>16}/{thread:x}/{process} {severity}: {message}, attrs: [{...}]";
+	        "{timestamp:l} {trace_id:{0:default}0>16}/{thread:x}/{process} {severity}: {message}, attrs: [{...}]";
 
 	static auto sevmap = [](std::size_t severity, const std::string &spec, blackhole::writer_t &writer) {
 		static const std::array<const char *, 5> mapping = {{"DEBUG", "NOTICE", "INFO", "WARNING", "ERROR"}};

--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -2895,10 +2895,12 @@ async_write_result session::bulk_write(const std::vector<dnet_io_attr> &ios, con
 }
 
 std::unique_ptr<dnet_logger> session::get_logger() const {
+	blackhole::attributes_t attrs;
+	if (get_trace_id()) {
+		attrs.emplace_back("trace_id", to_hex_string(get_trace_id()));
+	}
 	auto logger = get_base_logger(dnet_node_get_logger(get_native_node()));
-	return std::unique_ptr<dnet_logger>(new blackhole::wrapper_t(*logger, {
-		{"trace_id", to_hex_string(get_trace_id())}
-	}));
+	return std::unique_ptr<dnet_logger>(new blackhole::wrapper_t(*logger, std::move(attrs)));
 }
 
 dnet_node *session::get_native_node() const

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends: cdbs,
                eblob (>= 0.23.11),
                handystats (>= 1.11.0),
                libkora-util-dev (= 1.1.0-rc1),
-               blackhole-dev (>= 1.1.0-1),
+               blackhole-dev (>= 1.2.1-1),
                libcocaine-dev (>= 0.12.9), libcocaine-dev (<< 0.12.10),
                libcocaine-plugin-node-dev (>= 0.12.9), libcocaine-plugin-node-dev (<< 0.12.10),
                libcocaine-framework-native-dev (>= 0.12.9), libcocaine-framework-native-dev (<< 0.12.10),
@@ -40,7 +40,7 @@ Depends: ${shlibs:Depends},
          libkora-util1 (= 1.1.0-rc1),
          libcocaine-core3 (>= 0.12.9.0-alpha5), libcocaine-core3 (<< 0.12.10),
          libcocaine-plugin-node3 (>= 0.12.9), libcocaine-plugin-node3 (<< 0.12.10),
-         libblackhole1 (>= 1.1.0-1)
+         libblackhole1 (>= 1.2.1-1)
 Replaces: elliptics-2.10, srw
 Provides: elliptics-2.10
 Description: Distributed hash table storage
@@ -52,7 +52,7 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          msgpack-python | python-msgpack,
          handystats (>= 1.11.0),
-         libblackhole1 (>= 1.1.0-1),
+         libblackhole1 (>= 1.2.1-1),
 Replaces: elliptics-2.10
 Description: Distributed hash table storage (client library)
  Elliptics network is a fault tolerant distributed hash table object storage.

--- a/example/ioserv.json
+++ b/example/ioserv.json
@@ -5,7 +5,7 @@
 			{
 				"formatter": {
 					"type": "string",
-					"pattern": "{timestamp} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
+					"pattern": "{timestamp:l} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
 					"sevmap": ["DEBUG", "NOTICE", "INFO", "WARNING", "ERROR"]
 				},
 				"sinks": [{

--- a/example/ioserv.json
+++ b/example/ioserv.json
@@ -5,7 +5,7 @@
 			{
 				"formatter": {
 					"type": "string",
-					"pattern": "{timestamp} {trace_id}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
+					"pattern": "{timestamp} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
 					"sevmap": ["DEBUG", "NOTICE", "INFO", "WARNING", "ERROR"]
 				},
 				"sinks": [{

--- a/library/backend.h
+++ b/library/backend.h
@@ -51,7 +51,7 @@ struct dnet_backend_config_entry
 struct dnet_backend_info
 {
 	dnet_backend_info(dnet_logger &logger, uint32_t backend_id) :
-		log(new blackhole::wrapper_t(logger, {{"source", "eblob"}, {"trace_id", "0000000000000000"}, {"backend_id", backend_id}})),
+		log(new blackhole::wrapper_t(logger, {{"source", "eblob"}, {"backend_id", backend_id}})),
 		backend_id(backend_id), group(0), cache(NULL),
 		enable_at_start(false), read_only_at_start(false),
 		state_mutex(new std::mutex), state(DNET_BACKEND_UNITIALIZED),

--- a/srw/srw.cpp
+++ b/srw/srw.cpp
@@ -53,8 +53,6 @@ using blackhole::attribute_list;
 	}});
 
 namespace ioremap { namespace elliptics {
-static const blackhole::attribute_t default_trace_id{"trace_id", "0000000000000000"};
-
 /*
  * Logger interface implementation.
  */
@@ -64,51 +62,22 @@ public:
 	: blackhole::wrapper_t(*log, {{"source", "srw/cocaine"}}) {}
 
 	virtual void log(blackhole::severity_t severity, const blackhole::message_t &message) {
-		blackhole::attribute_list list;
-		list.emplace_back(default_trace_id);
-
-		blackhole::attribute_pack pack;
-		pack.push_back(list);
-
-		blackhole::wrapper_t::log(convert_severity(severity), message, pack);
+		blackhole::wrapper_t::log(convert_severity(severity), message);
 	}
 
 	virtual void
 	log(blackhole::severity_t severity, const blackhole::message_t &message, blackhole::attribute_pack &pack) {
 		//FIXME: is it possible to detect if trace_id is already set?
 		//XXX: what about tracebit? where to get it?
-		blackhole::attribute_list list;
-		if (!has_trace_id(pack)) {
-			list.emplace_back(default_trace_id);
-			pack.push_back(list);
-		}
-
 		blackhole::wrapper_t::log(convert_severity(severity), message, pack);
 	}
 
 	virtual void
 	log(blackhole::severity_t severity, const blackhole::lazy_message_t &message, blackhole::attribute_pack &pack) {
-		blackhole::attribute_list list;
-		if (!has_trace_id(pack)) {
-			list.emplace_back(default_trace_id);
-			pack.push_back(list);
-		}
-
 		blackhole::wrapper_t::log(convert_severity(severity), message, pack);
 	}
 
 private:
-	static bool has_trace_id(const blackhole::attribute_pack &pack) {
-		for (const auto &attributes: pack) {
-			for (const auto &attribute: attributes.get()) {
-				if (attribute.first == "trace_id") {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
 	static dnet_log_level convert_severity(blackhole::severity_t severity) {
 		switch (severity) {
 		case cocaine::logging::debug:

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -364,7 +364,7 @@ void server_config::write(const std::string &path) {
 	formatter.AddMember("type", "string", allocator);
 	formatter.AddMember("sevmap", sevmap, allocator);
 	formatter.AddMember("pattern",
-	                    "{timestamp} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
+	                    "{timestamp:l} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
 	                    allocator);
 
 	rapidjson::Value file_sink;

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -364,7 +364,7 @@ void server_config::write(const std::string &path) {
 	formatter.AddMember("type", "string", allocator);
 	formatter.AddMember("sevmap", sevmap, allocator);
 	formatter.AddMember("pattern",
-	                    "{timestamp} {trace_id}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
+	                    "{timestamp} {trace_id:{0:default}0>16}/{thread}/{process} {severity}: {message}, attrs: [{...}]",
 	                    allocator);
 
 	rapidjson::Value file_sink;


### PR DESCRIPTION
Get rid of using hard-coded default trace_id and specify local timezone in timestamp specification