### PR TITLE
logs: decreas number of logs printed on info level

### DIFF
--- a/library/net.c
+++ b/library/net.c
@@ -1333,12 +1333,11 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 	if (1) {
 		struct dnet_cmd *cmd = r->header ? r->header : r->data;
 		dnet_node_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
-		dnet_log(st->n, st->send_offset == 0 ? DNET_LOG_INFO : DNET_LOG_DEBUG,
-			"%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, start-sent: %zd/%zd",
-			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
-			dnet_addr_string(&st->addr), cmd->backend_id,
-			(unsigned long long)cmd->size, dnet_flags_dump_cflags(cmd->flags),
-			st->send_offset, total_size);
+		dnet_log(st->n, st->send_offset == 0 ? DNET_LOG_NOTICE : DNET_LOG_DEBUG,
+		         "%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, start-sent: %zd/%zd",
+		         dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
+		         dnet_addr_string(&st->addr), cmd->backend_id, (unsigned long long)cmd->size,
+		         dnet_flags_dump_cflags(cmd->flags), st->send_offset, total_size);
 	}
 
 	if (r->hsize && r->header && st->send_offset < r->hsize) {
@@ -1376,12 +1375,15 @@ err_out_exit:
 
 	if (1) {
 		struct dnet_cmd *cmd = r->header ? r->header : r->data;
-		dnet_log(st->n, st->send_offset == total_size ? DNET_LOG_INFO : DNET_LOG_DEBUG,
-			"%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, finish-sent: %zd/%zd",
-			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
-			dnet_addr_string(&st->addr), cmd->backend_id,
-			(unsigned long long)cmd->size, dnet_flags_dump_cflags(cmd->flags),
-			st->send_offset, total_size);
+		enum dnet_log_level level = DNET_LOG_DEBUG;
+		if (st->send_offset == total_size) {
+			level = !(cmd->flags & DNET_FLAGS_MORE) ? DNET_LOG_INFO : DNET_LOG_NOTICE;
+		}
+		dnet_log(st->n, level,
+		         "%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, finish-sent: %zd/%zd",
+		         dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
+		         dnet_addr_string(&st->addr), cmd->backend_id, (unsigned long long)cmd->size,
+		         dnet_flags_dump_cflags(cmd->flags), st->send_offset, total_size);
 	}
 	dnet_node_unset_trace_id();
 

--- a/library/pool.c
+++ b/library/pool.c
@@ -704,8 +704,8 @@ static int dnet_process_send_single(struct dnet_net_state *st)
 			 * another ready state.
 			 */
 			if (st->n->send_limit && ++counter >= st->n->send_limit) {
-				dnet_log(st->n, DNET_LOG_INFO, "Limit on number of packet sent to one state in a row "
-				                               "has been reached: limit: %" PRIu32,
+				dnet_log(st->n, DNET_LOG_NOTICE, "Limit on number of packet sent to one state in a row "
+				                                 "has been reached: limit: %" PRIu32,
 				         st->n->send_limit);
 				break;
 			}


### PR DESCRIPTION
Now net thread will print start/finish sent log on notice, intermediate sent log on debug and only final finish sent on info.
Also it will decrease level of log that is printed when a net thread switches from state because it has reached `send_limit`.