### PR TITLE
recovery: dump corrupted keys into {tmp_dir}/corrupted_keys file

### DIFF
--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -294,6 +294,8 @@ def main(options, args):
         log.error("Cleanup failed: {0}, traceback: {1}"
                   .format(repr(e), traceback.format_exc()))
 
+    ctx.corrupted_keys = open(os.path.join(ctx.tmp_dir, 'corrupted_keys'), 'w')
+
     log.info("Initializing monitor")
     monitor = Monitor(ctx, ctx.monitor_port)
     ctx.stats = monitor.stats
@@ -346,6 +348,7 @@ def main(options, args):
     monitor.shutdown()
     monitor.update()
     monitor.print_stat()
+    ctx.corrupted_keys.close()
     os.chdir(init_dir)
     return rc
 


### PR DESCRIPTION
Corrupted keys are dumped one per line and in follow format: `{key} {group} [address/backend]`.