### PR TITLE
Copy iterator interrupt

### DIFF
--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -1244,6 +1244,7 @@ struct dnet_server_send_request {
 	int		id_num;
 	int		group_num;
 	uint64_t	iflags;
+	uint64_t	reserved[10];
 };
 
 static inline void dnet_convert_server_send_request(struct dnet_server_send_request *req)

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -1244,7 +1244,6 @@ struct dnet_server_send_request {
 	int		id_num;
 	int		group_num;
 	uint64_t	iflags;
-	uint64_t	reserved[10];
 };
 
 static inline void dnet_convert_server_send_request(struct dnet_server_send_request *req)

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -673,6 +673,36 @@ static int dnet_server_send_sync(struct dnet_server_send_ctl *ctl)
 }
 
 /*
+ * This function initializes \a groups array using groups from \a send.
+ * Server-send should not write keys to itself: if a group contains source backend
+ * and write requests will be addressed to the same backend in this group,
+ * then the group will be skipped during initialization of \a groups.
+ * Returns number of initialized elements in \a groups.
+ */
+static int dnet_filter_invalid_groups(int *groups, const struct dnet_server_send_ctl *send, struct dnet_node *n, struct dnet_id *id)
+{
+	int num_groups = 0;
+	int i, backend_id;
+	const int group_id = dnet_group_id_search_by_backend(n->st, send->backend_id);
+	for (i = 0; i < send->group_num; ++i) {
+		// check that source and destination backends are not the same
+		if (group_id >= 0 && send->groups[i] == group_id) {
+			id->group_id = group_id;
+			struct dnet_net_state *st = dnet_state_get_first_with_backend(n, id, &backend_id);
+			dnet_state_put(st);
+			if (st == n->st && backend_id == send->backend_id) {
+				dnet_log(n, DNET_LOG_ERROR, "%s: Skip sending key to the group: source and destination backends are the same: "
+						 "backend_id: %d, group_id: %d",
+						 dnet_dump_id(&send->cmd.id), backend_id, group_id);
+				continue;
+			}
+		}
+		groups[num_groups++] = send->groups[i];
+	}
+	return num_groups;
+}
+
+/*
  * Helper function which sends given data as WRITE command to remote groups
  */
 int dnet_server_send_write(struct dnet_server_send_ctl *send,
@@ -684,8 +714,8 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 	struct dnet_io_control ctl;
 	struct dnet_session *s;
 	struct dnet_iterator_server_send_write_private *wp;
-	int i, backend_id;
-	int err;
+	int *groups, num_groups;
+	int err = 0;
 
 	dnet_server_send_get(send);
 
@@ -764,12 +794,27 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 	if (dnet_session_get_timeout(s)->tv_sec < 60)
 		dnet_session_set_timeout(s, 60);
 
-	err = dnet_session_set_groups(s, send->groups, send->group_num);
-	if (err) {
-		dnet_log(n, DNET_LOG_ERROR, "%s: Interrupting iterator because failed to set %d groups",
+	groups = malloc(send->group_num * sizeof(int));
+	if (!groups) {
+		dnet_log(n, DNET_LOG_ERROR, "%s: Interrupting iterator because failed to allocate groups array: num groups: %d",
 				dnet_dump_id(&send->cmd.id), send->group_num);
 		err = -ENOMEM;
 		goto err_out_session_destroy;
+	}
+
+	num_groups = dnet_filter_invalid_groups(groups, send, n, &ctl.id);
+	if (!num_groups) {
+		dnet_log(n, DNET_LOG_ERROR, "%s: %s: Failed to send key because no valid group available",
+				dnet_dump_id(&send->cmd.id), dnet_dump_id_str(re->key.id));
+		goto err_out_free_groups;
+	}
+
+	err = dnet_session_set_groups(s, groups, num_groups);
+	if (err) {
+		dnet_log(n, DNET_LOG_ERROR, "%s: Interrupting iterator because failed to set %d groups",
+				dnet_dump_id(&send->cmd.id), num_groups);
+		err = -ENOMEM;
+		goto err_out_free_groups;
 	}
 
 	atomic_add(&send->bytes_pending, re->size);
@@ -785,25 +830,6 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 			(unsigned long long)re->iterated_keys, (unsigned long long)re->total_keys,
 			atomic_read(&send->bytes_pending), send->bytes_pending_max);
 
-	// check that source and destination backends are not the same
-	const int group_id = dnet_group_id_search_by_backend(n->st, send->backend_id);
-	if (group_id >= 0) {
-		for (i = 0; i < send->group_num; ++i) {
-			if (send->groups[i] == group_id) {
-				ctl.id.group_id = group_id;
-				const struct dnet_net_state *st = dnet_state_get_first_with_backend(n, &ctl.id, &backend_id);
-				if (st == n->st && backend_id == send->backend_id) {
-					dnet_log(n, DNET_LOG_ERROR, "%s: Interrupting iterator: source and destination backends are the same: "
-						 "backend_id: %d, group_id: %d",
-						 dnet_dump_id(&send->cmd.id), backend_id, group_id);
-					err = -ENXIO;
-					goto err_out_session_destroy;
-				}
-				break;
-			}
-		}
-	}
-
 	/*
 	 * After calling this function we do not own @wp anymore
 	 * if we will have to perform some actions on it, its reference counter
@@ -815,8 +841,12 @@ int dnet_server_send_write(struct dnet_server_send_ctl *send,
 	if (!err)
 		err = send->write_error;
 
+	free(groups);
+
 	return err;
 
+err_out_free_groups:
+	free(groups);
 err_out_session_destroy:
 	dnet_session_destroy(s);
 err_out_free:

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -433,12 +433,12 @@ static int dnet_iterator_server_send_complete(struct dnet_addr *addr, struct dne
 		err = cmd->status;
 
 		/*
-		 * Write CAS error is not a real 'error' in that regard, that we do not remove
-		 * local record, but also do not stop iterator.
-		 *
 		 * Setting @write_error forces iterator to stop.
+		 *
+		 * Stop iteration only if connection was failed on write
+		 * or no space left on remote backend.
 		 */
-		if (err && !send->write_error && (err != -EBADFD))
+		if (err && !send->write_error && (err == -ETIMEDOUT || err == -ENXIO || err == -ENOSPC))
 			send->write_error = err;
 
 		if (atomic_dec_and_test(&wp->refcnt)) {

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -246,6 +246,8 @@ struct dnet_idc {
 	struct dnet_state_id	ids[];
 };
 
+int dnet_group_id_search_by_backend(struct dnet_net_state *st, int backend_id);
+
 int dnet_idc_insert(struct dnet_net_state *st, struct dnet_idc *idc);
 void dnet_idc_remove_backend_nolock(struct dnet_net_state *st, int backend_id);
 int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *ids);

--- a/library/node.c
+++ b/library/node.c
@@ -248,6 +248,19 @@ static struct dnet_idc *dnet_idc_search_backend_nolock(struct dnet_net_state *st
 	return NULL;
 }
 
+int dnet_group_id_search_by_backend(struct dnet_net_state *st, int backend_id)
+{
+	int group_id = -1;
+
+	pthread_rwlock_rdlock(&st->idc_lock);
+	struct dnet_idc *idc = dnet_idc_search_backend_nolock(st, backend_id);
+	if (idc && idc->group)
+		group_id = idc->group->group_id;
+	pthread_rwlock_unlock(&st->idc_lock);
+
+	return group_id;
+}
+
 int dnet_idc_insert_nolock(struct dnet_net_state *st, struct dnet_idc *idc_new)
 {
 	struct rb_root *root = &st->idc_root;

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -365,6 +365,13 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 				tests::create_session(n, {*g}, 0, 0), num, id_prefix, data_prefix);
 	}
 
+	// the fith stage - check that moving keys to itself doesn't permitted
+	iflags = DNET_IFLAGS_MOVE;
+	id_prefix = "server_send self write test";
+	data_prefix = "server_send self write data";
+	ELLIPTICS_TEST_CASE(ssend_test_insert_many_keys, src, num, id_prefix, data_prefix);
+	ELLIPTICS_TEST_CASE(ssend_test_copy, src, ssend_src_groups, 0, iflags, 0);
+
 	return true;
 }
 

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -79,10 +79,11 @@ static void ssend_configure(const std::string &path)
 
 static void ssend_test_insert_many_keys_old_ts(session &s, int num, const std::string &id_prefix, const std::string &data_prefix)
 {
+	std::vector<async_write_result> results;
 	s.set_trace_id(rand());
 	for (int i = 0; i < num; ++i) {
-		std::string id = id_prefix + lexical_cast(i);
-		std::string data = data_prefix + lexical_cast(i);
+		auto id = id_prefix + lexical_cast(i);
+		auto data = data_prefix + lexical_cast(i);
 
 		key k(id);
 		s.transform(k);
@@ -95,39 +96,59 @@ static void ssend_test_insert_many_keys_old_ts(session &s, int num, const std::s
 		dnet_current_time(&io.timestamp);
 		io.timestamp.tsec -= 1000;
 
-		ELLIPTICS_REQUIRE(res, s.write_data(io, data));
+		results.push_back(s.write_data(io, data));
+	}
+
+	for (auto &r : results) {
+		ELLIPTICS_REQUIRE(res, std::move(r));
 	}
 }
 
 static void ssend_test_insert_many_keys(session &s, int num, const std::string &id_prefix, const std::string &data_prefix)
 {
+	std::vector<async_write_result> results;
 	s.set_trace_id(rand());
 	for (int i = 0; i < num; ++i) {
-		std::string id = id_prefix + lexical_cast(i);
-		std::string data = data_prefix + lexical_cast(i);
+		auto id = id_prefix + lexical_cast(i);
+		auto data = data_prefix + lexical_cast(i);
 
-		ELLIPTICS_REQUIRE(res, s.write_data(id, data, 0));
+		results.push_back(s.write_data(id, data, 0));
+	}
+
+	for (auto &r : results) {
+		ELLIPTICS_REQUIRE(res, std::move(r));
 	}
 }
 
 static void ssend_test_read_many_keys(session &s, int num, const std::string &id_prefix, const std::string &data_prefix)
 {
+	std::vector<async_read_result> results;
 	s.set_trace_id(rand());
 	for (int i = 0; i < num; ++i) {
-		std::string id = id_prefix + lexical_cast(i);
-		std::string data = data_prefix + lexical_cast(i);
+		auto id = id_prefix + lexical_cast(i);
 
-		ELLIPTICS_COMPARE_REQUIRE(res, s.read_data(id, 0, 0), data);
+		results.push_back(s.read_data(id, 0, 0));
+	}
+
+	for (int i = 0; i < num; ++i) {
+		auto data = data_prefix + lexical_cast(i);
+
+		ELLIPTICS_COMPARE_REQUIRE(res, std::move(results[i]), data);
 	}
 }
 
 static void ssend_test_read_many_keys_error(session &s, int num, const std::string &id_prefix, int error)
 {
+	std::vector<async_read_result> results;
 	s.set_trace_id(rand());
 	for (int i = 0; i < num; ++i) {
-		std::string id = id_prefix + lexical_cast(i);
+		auto id = id_prefix + lexical_cast(i);
 
-		ELLIPTICS_REQUIRE_ERROR(res, s.read_data(id, 0, 0), error);
+		results.push_back(s.read_data(id, 0, 0));
+	}
+
+	for (auto &r : results) {
+		ELLIPTICS_REQUIRE_ERROR(res, std::move(r), error);
 	}
 }
 
@@ -231,14 +252,18 @@ static void ssend_test_server_send(session &s, int num, const std::string &id_pr
 	logger &log = s.get_logger();
 
 	s.set_trace_id(rand());
+	std::vector<async_write_result> write_results;
 	std::vector<std::string> keys;
 	for (int i = 0; i < num; ++i) {
-		std::string id = id_prefix + lexical_cast(i);
-		std::string data = data_prefix + lexical_cast(i);
+		auto id = id_prefix + lexical_cast(i);
+		auto data = data_prefix + lexical_cast(i);
 
-		ELLIPTICS_REQUIRE(res, s.write_data(id, data, 0));
-
+		write_results.push_back(s.write_data(id, data, 0));
 		keys.push_back(id);
+	}
+
+	for (auto &r : write_results) {
+		ELLIPTICS_REQUIRE(res, std::move(r));
 	}
 
 	BH_LOG(log, DNET_LOG_NOTICE, "%s: keys: %d, dst_groups: %s, starting copy",
@@ -365,7 +390,7 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 				tests::create_session(n, {*g}, 0, 0), num, id_prefix, data_prefix);
 	}
 
-	// the fith stage - check that moving keys to itself doesn't permitted
+	// the fifth stage - check that moving keys to itself doesn't permitted
 	iflags = DNET_IFLAGS_MOVE;
 	id_prefix = "server_send self write test";
 	data_prefix = "server_send self write data";

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -390,7 +390,9 @@ static bool ssend_register_tests(test_suite *suite, node &n)
 				tests::create_session(n, {*g}, 0, 0), num, id_prefix, data_prefix);
 	}
 
-	// the fifth stage - check that moving keys to itself doesn't permitted
+	// the fifth stage - check that copy-iterator doesn't move keys to itself:
+	// write many keys, move them using @start_copy_iterator() method with destination groups
+	// equal to the source groups and check that no keys were moved
 	iflags = DNET_IFLAGS_MOVE;
 	id_prefix = "server_send self write test";
 	data_prefix = "server_send self write data";


### PR DESCRIPTION
1. copy-iterator: stop iteration only if connection failed or no space left on remote backend
2. server-send: check that source and destination backends are not the same
3. server-send: added 80 reserved bytes to dnet_server_send_request struct