### PR TITLE
ioserv: fork process before logger initialization

### DIFF
--- a/example/common.c
+++ b/example/common.c
@@ -99,7 +99,6 @@ int dnet_parse_groups(char *value, int **groupsp)
 int dnet_background(void)
 {
 	pid_t pid;
-	int fd;
 
 	pid = fork();
 	if (pid == -1) {
@@ -113,6 +112,12 @@ int dnet_background(void)
 	}
 
 	setsid();
+
+	return 0;
+}
+
+int dnet_redirect_std_stream_to_dev_null(void) {
+	int fd;
 
 	close(0);
 	close(1);

--- a/example/common.h
+++ b/example/common.h
@@ -33,6 +33,7 @@ struct dnet_node *dnet_parse_config(const char *file, int mon);
 int dnet_parse_groups(char *value, int **groups);
 
 int dnet_background(void);
+int dnet_redirect_std_stream_to_dev_null(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
New blackhole may create worker threads that will be missed after process forking during daemonization.