### PR TITLE
recovery: optimizations

### DIFF
--- a/recovery/elliptics_recovery/utils/misc.py
+++ b/recovery/elliptics_recovery/utils/misc.py
@@ -22,6 +22,7 @@ import hashlib
 import errno
 import traceback
 import struct
+import msgpack
 import elliptics
 import time
 
@@ -327,13 +328,10 @@ class KeyInfo(object):
 
 
 def dump_key_data(key_data, file):
-    import msgpack
-    dump_data = (key_data[0].id, tuple(ki.dump() for ki in key_data[1]))
-    msgpack.pack(dump_data, file)
+    msgpack.pack((key_data[0].id, tuple(ki.dump() for ki in key_data[1])), file)
 
 
 def load_key_data_from_file(keys_file):
-    import msgpack
     unpacker = msgpack.Unpacker(keys_file)
     for data in unpacker:
         yield (elliptics.Id(data[0], 0), tuple(KeyInfo.load(d) for d in data[1]))


### PR DESCRIPTION
1. Get rid of extra temporary list creation in dump_key()
2. Removed is_chunked check (it must have been done in https://github.com/interiorem/elliptics/pull/68)
3. Optimized dump_key_data() that is called very often in inner cycles