### PR TITLE
Allow to override global queue timeout for a backend.

### DIFF
--- a/example/config.hpp
+++ b/example/config.hpp
@@ -90,6 +90,11 @@ struct config_data : public dnet_config_data {
 
 std::shared_ptr<dnet_backend_info> dnet_parse_backend(config_data *data, uint32_t backend_id, const kora::config_t &backend);
 
+/*
+ * Parse and return value of "queue_timeout" field of @options.
+ */
+uint64_t parse_queue_timeout(const kora::config_t &options);
+
 } } } // namespace ioremap::elliptics::config
 
 #endif // CONFIG_HPP

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -281,6 +281,7 @@ static int dnet_backend_init(struct dnet_node *node, size_t backend_id)
 	backend_io = dnet_get_backend_io(node->io, backend_id);
 	backend_io->need_exit = 0;
 	backend_io->read_only = backend->read_only_at_start;
+	backend_io->queue_timeout = backend->queue_timeout;
 
 	for (auto it = backend->options.begin(); it != backend->options.end(); ++it) {
 		const dnet_backend_config_entry &entry = *it;
@@ -935,6 +936,13 @@ void dnet_backend_info::parse(ioremap::elliptics::config::config_data *data,
 
 	io_thread_num = backend.at("io_thread_num", data->cfg_state.io_thread_num);
 	nonblocking_io_thread_num = backend.at("nonblocking_io_thread_num", data->cfg_state.nonblocking_io_thread_num);
+
+	// use backend's queue_timeout if it's specified otherwise use global one.
+	if (backend.has("queue_timeout")) {
+		queue_timeout = ioremap::elliptics::config::parse_queue_timeout(backend);
+	} else {
+		queue_timeout = data->queue_timeout;
+	}
 
 	for (int i = 0; i < config.num; ++i) {
 		dnet_config_entry &entry = config.ent[i];

--- a/library/backend.h
+++ b/library/backend.h
@@ -55,7 +55,8 @@ struct dnet_backend_info
 		backend_id(backend_id), group(0), cache(NULL),
 		enable_at_start(false), read_only_at_start(false),
 		state_mutex(new std::mutex), state(DNET_BACKEND_UNITIALIZED),
-		io_thread_num(0), nonblocking_io_thread_num(0)
+		io_thread_num(0), nonblocking_io_thread_num(0),
+		queue_timeout(0)
 	{
 		dnet_empty_time(&last_start);
 		last_start_err = 0;
@@ -84,7 +85,9 @@ struct dnet_backend_info
 		data(std::move(other.data)),
 		cache_config(std::move(other.cache_config)),
 		io_thread_num(other.io_thread_num),
-		nonblocking_io_thread_num(other.nonblocking_io_thread_num)
+		nonblocking_io_thread_num(other.nonblocking_io_thread_num),
+		queue_timeout(other.queue_timeout),
+		initial_config(std::move(other.initial_config))
 	{
 	}
 
@@ -108,6 +111,8 @@ struct dnet_backend_info
 		cache_config = std::move(other.cache_config);
 		io_thread_num = other.io_thread_num;
 		nonblocking_io_thread_num = other.nonblocking_io_thread_num;
+		queue_timeout = other.queue_timeout;
+		initial_config = other.initial_config;
 
 		return *this;
 	}
@@ -135,6 +140,7 @@ struct dnet_backend_info
 	std::unique_ptr<ioremap::cache::cache_config> cache_config;
 	int io_thread_num;
 	int nonblocking_io_thread_num;
+	uint64_t queue_timeout;
 	std::string initial_config;
 };
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -460,6 +460,7 @@ struct dnet_backend_io
 	struct dnet_backend_callbacks	*cb;
 	void				*cache;
 	void				*command_stats;
+	uint64_t			queue_timeout;
 };
 
 int dnet_backend_command_stats_init(struct dnet_backend_io *backend_io);

--- a/library/pool.c
+++ b/library/pool.c
@@ -202,8 +202,7 @@ int dnet_work_pool_alloc(struct dnet_work_pool_place *place, struct dnet_node *n
 	pool->n = n;
 	pool->io = io;
 
-	const int has_backend = io ? 1 : 0;
-	pool->request_queue = dnet_request_queue_create(n, has_backend);
+	pool->request_queue = dnet_request_queue_create(n, io);
 	if (!pool->request_queue) {
 		err = -ENOMEM;
 		goto err_out_mutex_destroy;

--- a/library/request_queue.h
+++ b/library/request_queue.h
@@ -116,7 +116,7 @@ private:
 extern "C" {
 #endif // __cplusplus
 
-void *dnet_request_queue_create(struct dnet_node *n, int has_backend);
+void *dnet_request_queue_create(struct dnet_node *n, const struct dnet_backend_io *backend);
 void dnet_request_queue_destroy(void *queue);
 
 void dnet_push_request(struct dnet_work_pool *pool, struct dnet_io_req *req);

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -50,7 +50,9 @@ static void fill_backend_backend(rapidjson::Value &stat_value,
 		if (json_stat && size) {
 			rapidjson::Document backend_value(&allocator);
 			backend_value.Parse<0>(json_stat);
-			backend_value["config"].AddMember("group", config_backend->group, allocator);
+			auto &config_value = backend_value["config"];
+			config_value.AddMember("group", config_backend->group, allocator);
+			config_value.AddMember("queue_timeout", config_backend->queue_timeout, allocator);
 
 			rapidjson::Document initial_config(&allocator);
 			initial_config.Parse<0>(config_backend->initial_config.c_str());


### PR DESCRIPTION
Now backends can have different queue_timeout.