### PR TITLE
logger: optimizations: 1) use std::vector instead of std::list in 'st…

### DIFF
--- a/example/config.cpp
+++ b/example/config.cpp
@@ -443,14 +443,6 @@ extern "C" int dnet_node_reset_log(struct dnet_node *n)
 	return 0;
 }
 
-extern "C" int dnet_node_get_verbosity(struct dnet_node *n) {
-	if (!n || !n->config_data || dnet_need_exit(n)) {
-		return -EINVAL;
-	}
-
-	return static_cast<config_data *>(n->config_data)->logger_level;
-}
-
 extern "C" int dnet_node_set_verbosity(struct dnet_node *n, enum dnet_log_level level) {
 	if (level < 0 || level > DNET_LOG_ERROR) {
 		return -EINVAL;

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -288,7 +288,7 @@ static int dnet_backend_init(struct dnet_node *node, size_t backend_id)
 		entry.entry->callback(&backend->config, entry.entry->key, entry.value_template.data());
 	}
 
-	err = backend->config.init(&backend->config, (dnet_log_level)dnet_node_get_verbosity(node));
+	err = backend->config.init(&backend->config, dnet_node_get_verbosity(node));
 	if (err) {
 		DNET_LOG_ERROR(node, "backend_init: backend: {}, failed to init backend: {}, elapsed: {}", backend_id,
 		               err, elapsed(start));

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -248,7 +248,7 @@ void dnet_node_stop_common_resources(struct dnet_node *n);
 void dnet_node_cleanup_common_resources(struct dnet_node *n);
 
 int dnet_node_reset_log(struct dnet_node *n);
-int dnet_node_get_verbosity(struct dnet_node *n);
+enum dnet_log_level dnet_node_get_verbosity(struct dnet_node *n);
 int dnet_node_set_verbosity(struct dnet_node *n, enum dnet_log_level level);
 
 int dnet_search_range(struct dnet_node *n, struct dnet_id *id,

--- a/library/logger.hpp
+++ b/library/logger.hpp
@@ -99,7 +99,15 @@ template <class T> inline blackhole::logger_facade<dnet_logger> make_facade(T &&
 
 #else
 #define DNET_LOG_RAW(...)		dnet_log_raw(__VA_ARGS__)
-#define DNET_LOG(node, ...)		DNET_LOG_RAW(dnet_node_get_logger(node), __VA_ARGS__)
+
+#define DNET_LOG(__node__, __severity__, ...)								\
+	do {												\
+		if (dnet_node_get_trace_bit() ||							\
+		    (enum dnet_log_level)(__severity__) >= dnet_node_get_verbosity(__node__)) { 	\
+			DNET_LOG_RAW(dnet_node_get_logger(__node__), __severity__, __VA_ARGS__);	\
+		}											\
+	} while (0)
+
 #define dnet_log(...)			DNET_LOG(__VA_ARGS__)
 
 #define DNET_LOG_DEBUG(log, ...)	DNET_LOG_RAW(log, DNET_LOG_DEBUG, __VA_ARGS__)


### PR DESCRIPTION
…ruct trace'; 2) check logging level in DNET_LOG macro