### PR TITLE
shareable io pools

### DIFF
--- a/bindings/cpp/callback.cpp
+++ b/bindings/cpp/callback.cpp
@@ -14,7 +14,12 @@
  * GNU Lesser General Public License for more details.
  */
 
+#include <blackhole/attribute.hpp>
+
 #include "callback_p.h"
+
+#include <blackhole/wrapper.hpp>
+
 #include "library/elliptics.h"
 #include "library/logger.hpp"
 

--- a/bindings/cpp/exception.cpp
+++ b/bindings/cpp/exception.cpp
@@ -14,7 +14,7 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include "../../include/elliptics/cppdef.h"
+#include "include/elliptics/cppdef.h"
 
 #include <cstdarg>
 #include <cstdio>

--- a/bindings/cpp/logger.cpp
+++ b/bindings/cpp/logger.cpp
@@ -67,8 +67,8 @@ static ssize_t &backend_id() {
 
 } /* namespace attributes */
 
-bool log_filter(const blackhole::record_t &record, const int level) {
-	return attributes::trace::bit() || record.severity() >= level;
+bool log_filter(const int severity, const int level) {
+	return attributes::trace::bit() || severity >= level;
 }
 
 std::unique_ptr<dnet_logger> make_file_logger(const std::string &path, dnet_log_level level) {
@@ -99,7 +99,7 @@ std::unique_ptr<dnet_logger> make_file_logger(const std::string &path, dnet_log_
 	std::unique_ptr<blackhole::root_logger_t> logger(new blackhole::root_logger_t(std::move(handlers)));
 
 	logger->filter([level](const blackhole::record_t &record) {
-		return log_filter(record, level);
+		return log_filter(record.severity(), level);
 	});
 
 	return std::move(logger);

--- a/bindings/cpp/logger.cpp
+++ b/bindings/cpp/logger.cpp
@@ -115,6 +115,10 @@ trace_scope::trace_scope(uint64_t trace_id, bool trace_bit) {
 	dnet_logger_set_trace_id(trace_id, trace_bit);
 }
 
+trace_scope::trace_scope(const session &s) {
+	dnet_logger_set_trace_id(s.get_trace_id(), s.get_trace_bit());
+}
+
 trace_scope::~trace_scope() {
 	dnet_logger_unset_trace_id();
 }
@@ -208,9 +212,8 @@ blackhole::attributes_t backend_wrapper_t::attributes() {
 
 dnet_logger *get_base_logger(dnet_logger *logger) {
 	auto wrapper = dynamic_cast<wrapper_t *>(logger);
-	if (wrapper) {
+	if (wrapper)
 		return wrapper->base_logger();
-	}
 	return logger;
 }
 
@@ -249,9 +252,8 @@ dnet_logger *dnet_node_get_logger(struct dnet_node* node) {
 }
 
 enum dnet_log_level dnet_node_get_verbosity(struct dnet_node *n) {
-	if (!n || !n->config_data) {
+	if (!n || !n->config_data)
 		return DNET_LOG_DEBUG;
-	}
 
 	return dnet_node_get_config_data(n)->logger_level;
 }
@@ -260,24 +262,22 @@ static const std::array<std::string, 5> severity_names = {{"debug", "notice", "i
 
 enum dnet_log_level dnet_log_parse_level(const char *name) {
 	auto it = std::find(severity_names.begin(), severity_names.end(), name);
-	if (it == severity_names.end()) {
+	if (it == severity_names.end())
 		throw std::logic_error(std::string{"Unknown log level: "} + name);
-	}
 
 	return static_cast<dnet_log_level>(it - severity_names.begin());
 }
 
 const char* dnet_log_print_level(enum dnet_log_level level) {
-	if (level > severity_names.size()) {
+	if (level > severity_names.size())
 		throw std::logic_error(std::string{"Unknown log level: "} + std::to_string(level));
-	}
+
 	return severity_names[level].c_str();
 }
 
 void dnet_log_raw(dnet_logger *logger, dnet_log_level level, const char *format, ...) {
-	if (!logger) {
+	if (!logger)
 		return;
-	}
 
 	char buffer[2048];
 

--- a/bindings/cpp/logger.cpp
+++ b/bindings/cpp/logger.cpp
@@ -9,64 +9,66 @@
 #include <blackhole/extensions/writer.hpp>
 #include <blackhole/formatter/string.hpp>
 #include <blackhole/handler/blocking.hpp>
+#include <blackhole/logger.hpp>
+#include <blackhole/record.hpp>
 #include <blackhole/root.hpp>
 #include <blackhole/sink/file.hpp>
-#include <blackhole/record.hpp>
-#include <blackhole/logger.hpp>
 
 #include "example/config.hpp"
 #include "elliptics/session.hpp"
-#include "library/elliptics.h"
 
 namespace ioremap { namespace elliptics {
+
+namespace attributes {
 struct trace {
 public:
-	trace(uint64_t trace_id, bool trace_bit)
-	: trace_id(trace_id)
-	, trace_bit(trace_bit) {}
+	static uint64_t id() {
+		return m_stack.empty() ? 0 : m_stack.top().m_id;
+	}
 
-	uint64_t trace_id;
-	bool trace_bit;
-
-	static trace current() {
-		return trace_stack.top();
+	static bool bit() {
+		return m_stack.empty() ? false : m_stack.top().m_bit;
 	}
 
 	static void pop() {
-		if (!trace_stack.empty()) {
-			trace_stack.pop();
-		}
+		if (!m_stack.empty())
+			m_stack.pop();
 	}
 
-	static void push(uint64_t trace_id, bool trace_bit) {
-		trace_stack.emplace(trace_id, trace_bit);
+	static void push(uint64_t id, bool bit) {
+		m_stack.push({id, bit});
 	}
 
 private:
-	static thread_local std::stack<trace, std::vector<trace>> trace_stack;
+	// constructor is private since trace should not be constructed outside.
+	trace(uint64_t id, bool bit)
+	: m_id(id)
+	, m_bit(bit) {}
+
+private:
+	uint64_t m_id;
+	bool m_bit;
+
+	static thread_local std::stack<trace, std::deque<trace>> m_stack;
+
 };
 
-thread_local std::stack<trace, std::vector<trace>> trace::trace_stack{{{0, false}}};
+thread_local std::stack<trace, std::deque<trace>> trace::m_stack;
 
 static std::string &pool_id() {
 	static thread_local std::string id;
 	return id;
 }
 
-struct backend {
-	backend(int id)
-	: id(id) {}
+static ssize_t &backend_id() {
+	static thread_local ssize_t id{-1};
+	return id;
+}
 
-	int id;
+} /* namespace attributes */
 
-	static backend &current() {
-		static thread_local backend current{-1};
-		return current;
-	}
-};
-
-bool log_filter(const blackhole::record_t &record, int level) {
-	return trace::current().trace_bit || record.severity() >= level;
+bool log_filter(const blackhole::record_t &record, const int level) {
+	return attributes::trace::bit() || record.severity() >= level;
 }
 
 std::unique_ptr<dnet_logger> make_file_logger(const std::string &path, dnet_log_level level) {
@@ -110,19 +112,19 @@ std::string to_hex_string(uint64_t value) {
 }
 
 trace_scope::trace_scope(uint64_t trace_id, bool trace_bit) {
-	dnet_node_set_trace_id(trace_id, trace_bit);
+	dnet_logger_set_trace_id(trace_id, trace_bit);
 }
 
 trace_scope::~trace_scope() {
-	dnet_node_unset_trace_id();
+	dnet_logger_unset_trace_id();
 }
 
 backend_scope::backend_scope(int backend_id) {
-	dnet_node_set_backend_id(backend_id);
+	dnet_logger_set_backend_id(backend_id);
 }
 
 backend_scope::~backend_scope() {
-	dnet_node_unset_backend_id();
+	dnet_logger_unset_backend_id();
 }
 
 static blackhole::attribute_list make_view(const blackhole::attributes_t &attributes) {
@@ -172,44 +174,36 @@ dnet_logger *wrapper_t::inner_logger() {
 
 dnet_logger *wrapper_t::base_logger() {
 	auto wrapper = dynamic_cast<wrapper_t *>(inner_logger());
-	if (wrapper) {
+	if (wrapper)
 		return wrapper->base_logger();
-	}
 
 	return inner_logger();
 }
 
 trace_wrapper_t::trace_wrapper_t(std::unique_ptr<dnet_logger> logger)
-: wrapper_t(std::move(logger)) {}
+: wrapper_t{std::move(logger)} {}
 
 blackhole::attributes_t trace_wrapper_t::attributes() {
-	if (trace::current().trace_id) {
-		// should be replaced by plain trace::current().trace_id when blackhole will
-		// remove used attributes from ... list
-		return {{"trace_id", to_hex_string(trace::current().trace_id)}};
-	}
-
-	return {};
+	// should be replaced by plain trace::id() when blackhole gets mapping
+	// and cocaine start to specify trace_id as uint64_t
+	return attributes::trace::id() ? blackhole::attributes_t{{"trace_id", to_hex_string(attributes::trace::id())}}
+	                               : blackhole::attributes_t{};
 }
 
 pool_wrapper_t::pool_wrapper_t(std::unique_ptr<dnet_logger> logger)
-: wrapper_t(std::move(logger)) {}
+: wrapper_t{std::move(logger)} {}
 
 blackhole::attributes_t pool_wrapper_t::attributes() {
-	return !pool_id().empty() ? blackhole::attributes_t{{"pool", pool_id()}}
+	return !attributes::pool_id().empty() ? blackhole::attributes_t{{"pool", attributes::pool_id()}}
 	                                      : blackhole::attributes_t{};
 }
 
 backend_wrapper_t::backend_wrapper_t(std::unique_ptr<dnet_logger> logger)
-: wrapper_t(std::move(logger)) {}
+: wrapper_t{std::move(logger)} {}
 
 blackhole::attributes_t backend_wrapper_t::attributes() {
-	blackhole::attributes_t attributes;
-	if (backend::current().id != -1) {
-		attributes.emplace_back("backend_id", backend::current().id);
-	}
-
-	return attributes;
+	return (attributes::backend_id() != -1) ? blackhole::attributes_t{{"backend_id", attributes::backend_id()}}
+	                                        : blackhole::attributes_t{};
 }
 
 dnet_logger *get_base_logger(dnet_logger *logger) {
@@ -222,32 +216,32 @@ dnet_logger *get_base_logger(dnet_logger *logger) {
 
 }} /* namespace ioremap::elliptics */
 
-void dnet_node_set_trace_id(uint64_t trace_id, int trace_bit) {
-	ioremap::elliptics::trace::push(trace_id, !!trace_bit);
+void dnet_logger_set_trace_id(uint64_t trace_id, int trace_bit) {
+	ioremap::elliptics::attributes::trace::push(trace_id, !!trace_bit);
 }
 
-void dnet_node_unset_trace_id() {
-	ioremap::elliptics::trace::pop();
+void dnet_logger_unset_trace_id() {
+	ioremap::elliptics::attributes::trace::pop();
 }
 
-uint64_t dnet_node_get_trace_bit() {
-	return ioremap::elliptics::trace::current().trace_bit ? (1ll << 63) : 0;
+uint64_t dnet_logger_get_trace_bit() {
+	return ioremap::elliptics::attributes::trace::bit() ? (1ll << 63) : 0;
 }
 
-void dnet_node_set_backend_id(int backend_id) {
-	ioremap::elliptics::backend::current() = {backend_id};
+void dnet_logger_set_backend_id(int backend_id) {
+	ioremap::elliptics::attributes::backend_id() = backend_id;
 }
 
-void dnet_node_unset_backend_id() {
-	ioremap::elliptics::backend::current() = {-1};
+void dnet_logger_unset_backend_id() {
+	ioremap::elliptics::attributes::backend_id() = -1;
 }
 
 void dnet_logger_set_pool_id(const char *pool_id) {
-	ioremap::elliptics::pool_id() = pool_id;
+	ioremap::elliptics::attributes::pool_id() = pool_id;
 }
 
 void dnet_logger_unset_pool_id() {
-	ioremap::elliptics::pool_id().clear();
+	ioremap::elliptics::attributes::pool_id().clear();
 }
 
 dnet_logger *dnet_node_get_logger(struct dnet_node* node) {
@@ -255,12 +249,11 @@ dnet_logger *dnet_node_get_logger(struct dnet_node* node) {
 }
 
 enum dnet_log_level dnet_node_get_verbosity(struct dnet_node *n) {
-	using namespace ioremap::elliptics::config;
 	if (!n || !n->config_data) {
 		return DNET_LOG_DEBUG;
 	}
 
-	return static_cast<config_data *>(n->config_data)->logger_level;
+	return dnet_node_get_config_data(n)->logger_level;
 }
 
 static const std::array<std::string, 5> severity_names = {{"debug", "notice", "info", "warning", "error"}};

--- a/bindings/cpp/newapi/result_entry.cpp
+++ b/bindings/cpp/newapi/result_entry.cpp
@@ -2,6 +2,7 @@
 #include "library/protocol.hpp"
 #include "library/elliptics.h"
 
+#include <algorithm>
 #include <fcntl.h>
 #include <queue>
 

--- a/bindings/cpp/newapi/session.cpp
+++ b/bindings/cpp/newapi/session.cpp
@@ -124,7 +124,7 @@ private:
 };
 
 async_lookup_result session::lookup(const key &id) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_lookup_result);
 	transform(id);
 
@@ -143,7 +143,7 @@ async_lookup_result session::lookup(const key &id) {
 }
 
 async_remove_result session::remove(const key &id) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_remove_request request;
@@ -307,7 +307,7 @@ async_read_result send_read(const session &orig_sess, const key &id, const dnet_
 }
 
 async_read_result session::read_json(const key &id) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_read_result);
 	transform(id);
 
@@ -324,7 +324,7 @@ async_read_result session::read_json(const key &id) {
 }
 
 async_read_result session::read_data(const key &id, uint64_t offset, uint64_t size) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_read_result);
 	transform(id);
 
@@ -343,7 +343,7 @@ async_read_result session::read_data(const key &id, uint64_t offset, uint64_t si
 }
 
 async_read_result session::read(const key &id, uint64_t offset, uint64_t size) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_read_result);
 	transform(id);
 
@@ -521,7 +521,7 @@ static dnet_write_request create_write_request(const session &sess)
 async_write_result session::write(const key &id,
                                   const argument_data &json, uint64_t json_capacity,
                                   const argument_data &data, uint64_t data_capacity) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	auto on_fail = [this](const error_info & error) {
@@ -579,7 +579,7 @@ async_write_result session::write(const key &id,
 async_lookup_result session::write_prepare(const key &id,
                                            const argument_data &json, uint64_t json_capacity,
                                            const argument_data &data, uint64_t data_offset, uint64_t data_capacity) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	auto on_fail = [this](const error_info & error) {
@@ -636,7 +636,7 @@ async_lookup_result session::write_prepare(const key &id,
 async_lookup_result session::write_plain(const key &id,
                                          const argument_data &json,
                                          const argument_data &data, uint64_t data_offset) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	try {
@@ -664,7 +664,7 @@ async_lookup_result session::write_plain(const key &id,
 async_lookup_result session::write_commit(const key &id,
                                           const argument_data &json,
                                           const argument_data &data, uint64_t data_offset, uint64_t data_commit_size) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	try {
@@ -694,7 +694,7 @@ async_lookup_result session::write_commit(const key &id,
 }
 
 async_lookup_result session::update_json(const key &id, const argument_data &json) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	try {
@@ -720,7 +720,7 @@ async_iterator_result session::start_iterator(const address &addr, uint32_t back
                                               uint64_t flags,
                                               const std::vector<dnet_iterator_range> &key_ranges,
                                               const std::tuple<dnet_time, dnet_time> &time_range) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (key_ranges.empty()) {
 		flags &= ~DNET_IFLAGS_KEY_RANGE;
 	} else {
@@ -770,7 +770,7 @@ async_iterator_result session::server_send(const std::vector<std::string> &keys,
 
 async_iterator_result session::server_send(const std::vector<key> &keys, uint64_t flags, uint64_t chunk_size,
                                            const int src_group, const std::vector<int> &dst_groups) {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (dst_groups.empty()) {
 		async_iterator_result result{*this};
 		async_result_handler<iterator_result_entry> handler{result};
@@ -946,7 +946,7 @@ private:
 };
 
 async_read_result send_bulk_read(session &sess, const std::vector<dnet_id> &keys, uint64_t read_flags) {
-	trace_scope scope{sess.get_trace_id(), sess.get_trace_bit()};
+	trace_scope scope{sess};
 
 	if (keys.empty()) {
 		async_read_result result{sess};

--- a/bindings/cpp/node.cpp
+++ b/bindings/cpp/node.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <vector>
 
+#include <blackhole/wrapper.hpp>
+
 #include "node_p.hpp"
 #include "library/elliptics.h"
 

--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -703,7 +703,7 @@ private:
 
 async_read_result session::read_data(const key &id, const std::vector<int> &groups, const dnet_io_attr &io, unsigned int cmd)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control control;
@@ -726,20 +726,20 @@ async_read_result session::read_data(const key &id, const std::vector<int> &grou
 
 async_read_result session::read_data(const key &id, const std::vector<int> &groups, const dnet_io_attr &io)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return read_data(id, groups, io, DNET_CMD_READ);
 }
 
 async_read_result session::read_data(const key &id, int group, const dnet_io_attr &io)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	const std::vector<int> groups(1, group);
 	return read_data(id, groups, io);
 }
 
 async_read_result session::read_data(const key &id, const std::vector<int> &groups, uint64_t offset, uint64_t size)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_attr io;
@@ -757,7 +757,7 @@ async_read_result session::read_data(const key &id, const std::vector<int> &grou
 
 async_read_result session::read_data(const key &id, uint64_t offset, uint64_t size)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_read_result);
 
 	return read_data(id, std::move(groups), offset, size);
@@ -796,7 +796,7 @@ struct read_latest_callback
 
 async_read_result session::read_latest(const key &id, uint64_t offset, uint64_t size)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_read_result);
 
 	session sess = clone();
@@ -813,7 +813,7 @@ async_read_result session::read_latest(const key &id, uint64_t offset, uint64_t 
 
 async_write_result session::write_data(const dnet_io_control &ctl)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	dnet_io_control ctl_copy = ctl;
 
 	ctl_copy.cmd = DNET_CMD_WRITE;
@@ -835,7 +835,7 @@ async_write_result session::write_data(const dnet_io_control &ctl)
 
 async_write_result session::write_data(const dnet_io_attr &io, const argument_data &file)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	dnet_io_control ctl;
 	memset(&ctl, 0, sizeof(ctl));
 	dnet_empty_time(&ctl.io.timestamp);
@@ -859,7 +859,7 @@ async_write_result session::write_data(const dnet_io_attr &io, const argument_da
 
 async_write_result session::write_data(const key &id, const argument_data &file, uint64_t remote_offset)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control ctl;
@@ -946,7 +946,7 @@ struct chunk_handler : public std::enable_shared_from_this<chunk_handler> {
 
 async_write_result session::write_data(const key &id, const data_pointer &file, uint64_t remote_offset, uint64_t chunk_size)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (file.size() <= chunk_size || chunk_size == 0)
 		return write_data(id, file, remote_offset);
 
@@ -1142,7 +1142,7 @@ struct cas_functor : std::enable_shared_from_this<cas_functor>
 async_write_result session::write_cas(const key &id, const std::function<data_pointer (const data_pointer &)> &converter,
 		uint64_t remote_offset, int count)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_write_result);
 
 	async_write_result result(*this);
@@ -1155,7 +1155,7 @@ async_write_result session::write_cas(const key &id, const std::function<data_po
 
 async_write_result session::write_cas(const key &id, const argument_data &file, const dnet_id &old_csum, uint64_t remote_offset)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 	dnet_id raw = id.id();
 
@@ -1183,7 +1183,7 @@ async_write_result session::write_cas(const key &id, const argument_data &file, 
 
 async_write_result session::write_prepare(const key &id, const argument_data &file, uint64_t remote_offset, uint64_t psize)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control ctl;
@@ -1209,7 +1209,7 @@ async_write_result session::write_prepare(const key &id, const argument_data &fi
 
 async_write_result session::write_plain(const key &id, const argument_data &file, uint64_t remote_offset)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control ctl;
@@ -1236,7 +1236,7 @@ async_write_result session::write_plain(const key &id, const argument_data &file
 
 async_write_result session::write_commit(const key &id, const argument_data &file, uint64_t remote_offset, uint64_t csize)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control ctl;
@@ -1261,7 +1261,7 @@ async_write_result session::write_commit(const key &id, const argument_data &fil
 
 async_write_result session::write_cache(const key &id, const argument_data &file, long timeout)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 	dnet_id raw = id.id();
 
@@ -1288,7 +1288,7 @@ async_write_result session::write_cache(const key &id, const argument_data &file
 // TODO: Remove this method in elliptics-2.27
 std::string session::lookup_address(const key &id, int group_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	char buf[128];
 	struct dnet_addr addr;
 	int backend_id = -1;
@@ -1357,7 +1357,7 @@ private:
 
 async_lookup_result session::lookup(const key &id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	DNET_SESSION_GET_GROUPS(async_lookup_result);
 
 	transport_control control(id.id(), DNET_CMD_LOOKUP, DNET_FLAGS_NEED_ACK);
@@ -1372,7 +1372,7 @@ async_lookup_result session::lookup(const key &id)
 
 async_lookup_result session::parallel_lookup(const key &id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	transport_control control(id.id(), DNET_CMD_LOOKUP, DNET_FLAGS_NEED_ACK);
@@ -1449,7 +1449,7 @@ struct prepare_latest_functor
 
 async_lookup_result session::prepare_latest(const key &id, const std::vector<int> &groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	async_lookup_result result(*this);
 	async_result_handler<lookup_result_entry> result_handler(result);
 	result_handler.set_total(groups.size());
@@ -1592,7 +1592,7 @@ struct quorum_lookup_aggregator_handler
 // In both cases result also contains lookup_result_entries with error info
 async_lookup_result session::quorum_lookup(const key &id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	// The only thing doing here: connecting helper class to async_results
 	transform(id);
 
@@ -1624,7 +1624,7 @@ async_lookup_result session::quorum_lookup(const key &id)
 
 async_remove_result session::remove(const key &id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	dnet_io_control ctl;
@@ -1646,7 +1646,7 @@ async_remove_result session::remove(const key &id)
 
 async_monitor_stat_result session::monitor_stat(uint64_t categories)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	dnet_monitor_stat_request request;
 	memset(&request, 0, sizeof(struct dnet_monitor_stat_request));
 	request.categories = categories;
@@ -1663,7 +1663,7 @@ async_monitor_stat_result session::monitor_stat(uint64_t categories)
 
 async_monitor_stat_result session::monitor_stat(const address &addr, uint64_t categories)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	dnet_monitor_stat_request request;
 	memset(&request, 0, sizeof(struct dnet_monitor_stat_request));
 	request.categories = categories;
@@ -1686,19 +1686,19 @@ int session::state_num(void)
 
 async_generic_result session::request_cmd(const transport_control &ctl)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return send_to_each_backend(*this, ctl);
 }
 
 async_generic_result session::request_single_cmd(const transport_control &ctl)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return send_to_single_state(*this, ctl);
 }
 
 async_node_status_result session::update_status(const address &addr, const dnet_node_status &status)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	data_pointer data = data_pointer::allocate(sizeof(dnet_node_status));
 	dnet_node_status *node_status = data.data<dnet_node_status>();
 	*node_status = status;
@@ -1715,7 +1715,7 @@ async_node_status_result session::update_status(const address &addr, const dnet_
 
 async_node_status_result session::request_node_status(const address &addr)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	struct dnet_node_status node_status;
 	memset(&node_status, 0, sizeof(struct dnet_node_status));
 	node_status.nflags = -1;
@@ -1784,25 +1784,25 @@ static async_backend_control_result update_backend_status(const backend_status_p
 
 async_backend_control_result session::enable_backend(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_ENABLE));
 }
 
 async_backend_control_result session::disable_backend(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_DISABLE));
 }
 
 async_backend_control_result session::remove_backend(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_REMOVE));
 }
 
 async_backend_control_result session::start_defrag(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	backend_status_params params(*this, addr, backend_id, DNET_BACKEND_START_DEFRAG);
 	params.defrag_level = DNET_BACKEND_DEFRAG_FULL;
 	return update_backend_status(params);
@@ -1810,7 +1810,7 @@ async_backend_control_result session::start_defrag(const address &addr, uint32_t
 
 async_backend_control_result session::start_compact(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	backend_status_params params(*this, addr, backend_id, DNET_BACKEND_START_DEFRAG);
 	params.defrag_level = DNET_BACKEND_DEFRAG_COMPACT;
 	return update_backend_status(params);
@@ -1818,14 +1818,14 @@ async_backend_control_result session::start_compact(const address &addr, uint32_
 
 async_backend_control_result session::stop_defrag(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_STOP_DEFRAG));
 }
 
 async_backend_control_result session::set_backend_ids(const address &addr, uint32_t backend_id,
 		const std::vector<dnet_raw_id> &ids)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	backend_status_params params(*this, addr, backend_id, DNET_BACKEND_SET_IDS);
 	params.ids = ids;
 	return update_backend_status(params);
@@ -1833,19 +1833,19 @@ async_backend_control_result session::set_backend_ids(const address &addr, uint3
 
 async_backend_control_result session::make_readonly(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_READ_ONLY));
 }
 
 async_backend_control_result session::make_writable(const address &addr, uint32_t backend_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	return update_backend_status(backend_status_params(*this, addr, backend_id, DNET_BACKEND_WRITEABLE));
 }
 
 async_backend_control_result session::set_delay(const address &addr, uint32_t backend_id, uint32_t delay)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	backend_status_params params(*this, addr, backend_id, DNET_BACKEND_CTL);
 	params.delay = delay;
 	return update_backend_status(params);
@@ -1853,7 +1853,7 @@ async_backend_control_result session::set_delay(const address &addr, uint32_t ba
 
 async_backend_status_result session::request_backends_status(const address &addr)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transport_control control;
 	control.set_command(DNET_CMD_BACKEND_STATUS);
 	control.set_cflags(DNET_FLAGS_NEED_ACK | DNET_FLAGS_DIRECT);
@@ -2067,7 +2067,7 @@ class remove_data_range_callback : public read_data_range_callback
 
 async_read_result session::read_data_range(const dnet_io_attr &io, int group_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	async_read_result result(*this);
 	async_result_handler<read_result_entry> handler(result);
 	error_info error;
@@ -2079,7 +2079,7 @@ async_read_result session::read_data_range(const dnet_io_attr &io, int group_id)
 
 async_read_result session::remove_data_range(const dnet_io_attr &io, int group_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	async_read_result result(*this);
 	async_result_handler<read_result_entry> handler(result);
 	error_info error;
@@ -2091,7 +2091,7 @@ async_read_result session::remove_data_range(const dnet_io_attr &io, int group_i
 
 std::vector<dnet_route_entry> session::get_routes()
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 
 	cstyle_scoped_pointer<dnet_route_entry> entries;
 
@@ -2105,7 +2105,7 @@ std::vector<dnet_route_entry> session::get_routes()
 
 async_iterator_result session::iterator(const key &id, const data_pointer& request)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (get_groups().empty()) {
 		async_iterator_result result(*this);
 		async_result_handler<iterator_result_entry> handler(result);
@@ -2137,7 +2137,7 @@ async_iterator_result session::iterator(const key &id, const data_pointer& reque
 
 error_info session::mix_states(const key &id, std::vector<int> &groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	transform(id);
 
 	cstyle_scoped_pointer<int> groups_ptr;
@@ -2157,7 +2157,7 @@ error_info session::mix_states(const key &id, std::vector<int> &groups)
 async_iterator_result session::start_iterator(const key &id, const std::vector<dnet_iterator_range>& ranges,
 		uint32_t type, uint64_t flags, const dnet_time& time_begin, const dnet_time& time_end)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (type == DNET_ITYPE_SERVER_SEND) {
 		async_iterator_result result(*this);
 		async_result_handler<iterator_result_entry> handler(result);
@@ -2191,7 +2191,7 @@ async_iterator_result session::start_copy_iterator(const key &id,
 		const dnet_time& time_begin, const dnet_time& time_end,
 		const std::vector<int> &dst_groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	size_t ranges_size = ranges.size() * sizeof(ranges.front());
 	size_t groups_size = dst_groups.size() * sizeof(dst_groups.front());
 
@@ -2227,7 +2227,7 @@ async_iterator_result session::start_copy_iterator(const key &id,
 
 async_iterator_result session::pause_iterator(const key &id, uint64_t iterator_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	data_pointer data = data_pointer::allocate(sizeof(dnet_iterator_request));
 	auto request = data.data<dnet_iterator_request>();
 	memset(request, 0, sizeof(dnet_iterator_request));
@@ -2239,7 +2239,7 @@ async_iterator_result session::pause_iterator(const key &id, uint64_t iterator_i
 
 async_iterator_result session::continue_iterator(const key &id, uint64_t iterator_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	data_pointer data = data_pointer::allocate(sizeof(dnet_iterator_request));
 	auto request = data.data<dnet_iterator_request>();
 	memset(request, 0, sizeof(dnet_iterator_request));
@@ -2251,7 +2251,7 @@ async_iterator_result session::continue_iterator(const key &id, uint64_t iterato
 
 async_iterator_result session::cancel_iterator(const key &id, uint64_t iterator_id)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	data_pointer data = data_pointer::allocate(sizeof(dnet_iterator_request));
 	auto request = data.data<dnet_iterator_request>();
 	memset(request, 0, sizeof(dnet_iterator_request));
@@ -2263,7 +2263,7 @@ async_iterator_result session::cancel_iterator(const key &id, uint64_t iterator_
 
 async_iterator_result session::server_send(const std::vector<key> &keys, uint64_t iflags, const std::vector<int> &groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (get_groups().empty()) {
 		async_iterator_result result(*this);
 		async_result_handler<iterator_result_entry> handler(result);
@@ -2388,7 +2388,7 @@ async_iterator_result session::server_send(const std::vector<key> &keys, uint64_
 
 async_iterator_result session::server_send(const std::vector<dnet_raw_id> &ids, uint64_t iflags, const std::vector<int> &groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<key> keys;
 	for (auto id = ids.begin(), id_end = ids.end(); id != id_end; ++id) {
 		keys.emplace_back(*id);
@@ -2399,7 +2399,7 @@ async_iterator_result session::server_send(const std::vector<dnet_raw_id> &ids, 
 
 async_iterator_result session::server_send(const std::vector<std::string> &strs, uint64_t iflags, const std::vector<int> &groups)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<key> keys;
 	for (auto s = strs.begin(), send = strs.end(); s != send; ++s) {
 		key k(*s);
@@ -2547,7 +2547,7 @@ private:
 
 async_read_result session::bulk_read(const std::vector<dnet_io_attr> &ios_vector)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (ios_vector.empty()) {
 		error_info error = create_error(-EINVAL, "bulk_read failed: ios list is empty");
 		if (get_exceptions_policy() & throw_at_start) {
@@ -2587,7 +2587,7 @@ async_read_result session::bulk_read(const std::vector<dnet_io_attr> &ios_vector
 
 async_read_result session::bulk_read(const std::vector<std::string> &keys)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<dnet_io_attr> ios;
 	dnet_io_attr io;
 	memset(&io, 0, sizeof(io));
@@ -2609,7 +2609,7 @@ async_read_result session::bulk_read(const std::vector<std::string> &keys)
 
 async_read_result session::bulk_read(const std::vector<key> &keys)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<dnet_io_attr> ios;
 	dnet_io_attr io;
 	memset(&io, 0, sizeof(io));
@@ -2630,7 +2630,7 @@ async_read_result session::bulk_read(const std::vector<key> &keys)
 
 async_write_result session::bulk_write(const std::vector<dnet_io_attr> &ios, const std::vector<argument_data> &data)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	if (ios.size() != data.size()) {
 		error_info error = create_error(-EINVAL, "BULK_WRITE: ios doesn't meet data: io.size: %zd, data.size: %zd",
 			ios.size(), data.size());
@@ -2664,7 +2664,7 @@ async_write_result session::bulk_write(const std::vector<dnet_io_attr> &ios, con
 
 async_remove_result session::bulk_remove(const std::vector<key> &keys)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<async_remove_result> results;
 
 	{
@@ -2685,7 +2685,7 @@ async_remove_result session::bulk_remove(const std::vector<key> &keys)
 
 async_write_result session::bulk_write(const std::vector<dnet_io_attr> &ios, const std::vector<std::string> &data)
 {
-	trace_scope scope{get_trace_id(), get_trace_bit()};
+	trace_scope scope{*this};
 	std::vector<argument_data> pointer_data;
 	pointer_data.reserve(data.size());
 	for (auto it = data.begin(); it != data.end(); ++it)

--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -1774,7 +1774,7 @@ static async_backend_control_result update_backend_status(const backend_status_p
 	transport_control control;
 	control.set_key(id);
 	control.set_command(DNET_CMD_BACKEND_CONTROL);
-	control.set_cflags(DNET_FLAGS_NEED_ACK | DNET_FLAGS_DIRECT);
+	control.set_cflags(DNET_FLAGS_NEED_ACK | DNET_FLAGS_DIRECT | params.orig_sess.get_cflags());
 	control.set_data(data.data(), data.size());
 
 	session sess = params.orig_sess.clean_clone();

--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -18,19 +18,16 @@
 #include "cache.hpp"
 #include "slru_cache.hpp"
 
-#include <fstream>
+#include <blackhole/attribute.hpp>
+#include <kora/config.hpp>
 
+#include "library/backend.h"
 #include "library/protocol.hpp"
 
-#include "monitor/monitor.h"
-#include "monitor/monitor.hpp"
-#include "monitor/statistics.hpp"
 #include "monitor/measure_points.h"
 #include "rapidjson/document.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
 
-#include "../example/config.hpp"
+#include "example/config.hpp"
 
 namespace ioremap { namespace cache {
 
@@ -104,17 +101,17 @@ static size_t parse_size(const kora::config_t &value) {
 	return ret;
 }
 
-std::unique_ptr<cache_config> cache_config::parse(const kora::config_t &cache) {
-	cache_config config;
-	config.size = parse_size(cache["size"]);
-	config.count = cache.at<size_t>("shards", DNET_DEFAULT_CACHES_NUMBER);
-	config.sync_timeout = cache.at<unsigned>("sync_timeout", DNET_DEFAULT_CACHE_SYNC_TIMEOUT_SEC);
-	config.pages_proportions =
-	    cache.at("pages_proportions", std::vector<size_t>(DNET_DEFAULT_CACHE_PAGES_NUMBER, 1));
-	return std::unique_ptr<cache_config>(new cache_config(config));
+cache_config cache_config::parse(const kora::config_t &cache) {
+	return {/*size*/ parse_size(cache["size"]),
+	        /*count*/ cache.at<size_t>("shards", DNET_DEFAULT_CACHES_NUMBER),
+	        /*sync_timeout*/ cache.at<unsigned>("sync_timeout", DNET_DEFAULT_CACHE_SYNC_TIMEOUT_SEC),
+	        /*pages_proportions*/ cache.at("pages_proportions",
+	                                       std::vector<size_t>(DNET_DEFAULT_CACHE_PAGES_NUMBER, 1))};
 }
 
-cache_manager::cache_manager(dnet_backend_io *backend, dnet_node *n, const cache_config &config) : m_node(n) {
+cache_manager::cache_manager(dnet_node *n, dnet_backend &backend, const cache_config &config)
+: m_node(n)
+, m_need_exit(false) {
 	size_t caches_number = config.count;
 	m_cache_pages_number = config.pages_proportions.size();
 	m_max_cache_size = config.size;
@@ -131,8 +128,13 @@ cache_manager::cache_manager(dnet_backend_io *backend, dnet_node *n, const cache
 	}
 
 	for (size_t i = 0; i < caches_number; ++i) {
-		m_caches.emplace_back(std::make_shared<slru_cache_t>(backend, n, pages_max_sizes, config.sync_timeout));
+		m_caches.emplace_back(
+		        std::make_shared<slru_cache_t>(n, backend, pages_max_sizes, config.sync_timeout, m_need_exit));
 	}
+}
+
+cache_manager::~cache_manager() {
+	m_need_exit = true;
 }
 
 write_response_t cache_manager::write(dnet_net_state *st,
@@ -186,51 +188,25 @@ cache_stats cache_manager::get_total_cache_stats() const {
 	return stats;
 }
 
-std::vector<cache_stats> cache_manager::get_caches_stats() const {
-	std::vector<cache_stats> caches_stats;
-	for (size_t i = 0; i < m_caches.size(); ++i) {
-		caches_stats.push_back(m_caches[i]->get_cache_stats());
-	}
-	return caches_stats;
-}
-
-rapidjson::Value &cache_manager::get_total_caches_size_stats_json(rapidjson::Value &stat_value,
-                                                                  rapidjson::Document::AllocatorType &allocator) const {
-	cache_stats stats = get_total_cache_stats();
-	return stats.to_json(stat_value, allocator);
-}
-
-rapidjson::Value &cache_manager::get_caches_size_stats_json(rapidjson::Value &stat_value,
-                                                            rapidjson::Document::AllocatorType &allocator) const {
-	for (size_t i = 0; i < m_caches.size(); ++i) {
-		rapidjson::Value cache_time_stats(rapidjson::kObjectType);
-		stat_value.AddMember(std::to_string(static_cast<unsigned long long>(i)).c_str(), allocator,
-		                     m_caches[i]->get_cache_stats().to_json(cache_time_stats, allocator), allocator);
-	}
-	return stat_value;
-}
-
-std::string cache_manager::stat_json() const {
-	rapidjson::Document doc;
-	doc.SetObject();
-	auto &allocator = doc.GetAllocator();
+void cache_manager::statistics(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) const {
+	value.SetObject();
 
 	rapidjson::Value total_cache(rapidjson::kObjectType);
-
-	rapidjson::Value size_stats(rapidjson::kObjectType);
-	get_total_caches_size_stats_json(size_stats, allocator);
-
-	total_cache.AddMember("size_stats", size_stats, allocator);
-	doc.AddMember("total_cache", total_cache, allocator);
+	{
+		rapidjson::Value size_stats(rapidjson::kObjectType);
+		get_total_cache_stats().to_json(size_stats, allocator);
+		total_cache.AddMember("size_stats", size_stats, allocator);
+	}
+	value.AddMember("total_cache", total_cache, allocator);
 
 	rapidjson::Value caches(rapidjson::kObjectType);
-	get_caches_size_stats_json(caches, allocator);
-	doc.AddMember("caches", caches, allocator);
-
-	rapidjson::StringBuffer buffer;
-	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	doc.Accept(writer);
-	return buffer.GetString();
+	for (size_t i = 0; i < m_caches.size(); ++i) {
+		const auto &index = std::to_string(i);
+		rapidjson::Value cache_time_stats(rapidjson::kObjectType);
+		m_caches[i]->get_cache_stats().to_json(cache_time_stats, allocator);
+		caches.AddMember(index.c_str(), allocator, cache_time_stats, allocator);
+	}
+	value.AddMember("caches", caches, allocator);
 }
 
 size_t cache_manager::idx(const unsigned char *id) {
@@ -471,8 +447,7 @@ static int dnet_cmd_cache_io_read_new(struct cache_manager *cache,
 	return dnet_send_data(st, response.data(), response.size(), data_p.data(), data_p.size());
 }
 
-static int dnet_cmd_cache_io_lookup(struct dnet_backend_io *backend,
-                                    struct cache_manager *cache,
+static int dnet_cmd_cache_io_lookup(struct dnet_backend *backend,
                                     struct dnet_net_state *st,
                                     struct dnet_cmd *cmd,
                                     struct dnet_cmd_stats *cmd_stats) {
@@ -481,14 +456,14 @@ static int dnet_cmd_cache_io_lookup(struct dnet_backend_io *backend,
 	int err;
 	cache_item it;
 
-	std::tie(err, it) = cache->lookup(cmd->id.id);
+	std::tie(err, it) = backend->cache()->lookup(cmd->id.id);
 	if (err) {
 		return err;
 	}
 
 
 	// go check object on disk
-	local_session sess(backend, st->n);
+	local_session sess(*backend, st->n);
 	cmd->flags |= DNET_FLAGS_NOCACHE;
 	ioremap::elliptics::data_pointer data = sess.lookup(*cmd, &err);
 	cmd->flags &= ~DNET_FLAGS_NOCACHE;
@@ -576,123 +551,57 @@ static int dnet_cmd_cache_io_remove_new(struct cache_manager *cache,
 	return err;
 }
 
-int dnet_cmd_cache_io(struct dnet_backend_io *backend,
+int dnet_cmd_cache_io(struct dnet_backend *backend,
                       struct dnet_net_state *st,
                       struct dnet_cmd *cmd,
-                      struct dnet_io_attr *io,
                       char *data,
                       struct dnet_cmd_stats *cmd_stats) {
-	struct dnet_node *n = st->n;
-	int err = -ENOTSUP;
-
-	if (!backend->cache) {
-		if (io->flags & DNET_IO_FLAGS_CACHE) {
-			DNET_LOG_NOTICE(n, "{}: cache is not supported", dnet_dump_id(&cmd->id));
+	auto io = [ cmd, &data ]() -> struct dnet_io_attr * {
+		switch (cmd->cmd) {
+		case DNET_CMD_WRITE:
+		case DNET_CMD_READ:
+		case DNET_CMD_DEL:
+			auto ret = reinterpret_cast<struct dnet_io_attr*>(data);
+			data += sizeof(struct dnet_io_attr);
+			return ret;
 		}
+		return nullptr;
+	}();
+
+	auto cache = backend->cache();
+	if (!cache) {
+		if (io && (io->flags & DNET_IO_FLAGS_CACHE))
+			DNET_LOG_NOTICE(st->n, "{}: cache is not supported", dnet_dump_id(&cmd->id));
 		return -ENOTSUP;
 	}
-
-	auto cache = reinterpret_cast<cache_manager *>(backend->cache);
 
 	FORMATTED(HANDY_TIMER_SCOPE, ("cache.%s", dnet_cmd_string(cmd->cmd)));
 
 	try {
 		switch (cmd->cmd) {
 		case DNET_CMD_WRITE:
-			err = dnet_cmd_cache_io_write(cache, st, cmd, io, data, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_write(cache, st, cmd, io, data, cmd_stats);
 		case DNET_CMD_READ:
-			err = dnet_cmd_cache_io_read(cache, st, cmd, io, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_read(cache, st, cmd, io, cmd_stats);
+		case DNET_CMD_LOOKUP:
+			return dnet_cmd_cache_io_lookup(backend, st, cmd, cmd_stats);
 		case DNET_CMD_DEL:
-			err = dnet_cmd_cache_io_remove(cache, cmd, io, cmd_stats);
-			break;
-		}
-	} catch (const std::exception &e) {
-		DNET_LOG_ERROR(n, "{}: {} cache operation failed: {}", dnet_dump_id(&cmd->id),
-		               dnet_cmd_string(cmd->cmd), e.what());
-		err = -ENOENT;
-	}
-
-	return err;
-}
-
-int dnet_cmd_cache_io_new(struct dnet_backend_io *backend,
-                          struct dnet_net_state *st,
-                          struct dnet_cmd *cmd,
-                          void *data,
-                          struct dnet_cmd_stats *cmd_stats) {
-	struct dnet_node *n = st->n;
-	int err = -ENOTSUP;
-
-	if (!backend->cache) {
-		DNET_LOG_NOTICE(n, "{}: cache is not supported", dnet_dump_id(&cmd->id));
-		return -ENOTSUP;
-	}
-
-	auto cache = reinterpret_cast<cache_manager *>(backend->cache);
-
-	FORMATTED(HANDY_TIMER_SCOPE, ("cache.%s", dnet_cmd_string(cmd->cmd)));
-
-	try {
-		switch (cmd->cmd) {
+			return dnet_cmd_cache_io_remove(cache, cmd, io, cmd_stats);
 		case DNET_CMD_WRITE_NEW:
-			err = dnet_cmd_cache_io_write_new(cache, st, cmd, data, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_write_new(cache, st, cmd, data, cmd_stats);
 		case DNET_CMD_READ_NEW:
-			err = dnet_cmd_cache_io_read_new(cache, st, cmd, data, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_read_new(cache, st, cmd, data, cmd_stats);
 		case DNET_CMD_LOOKUP_NEW:
-			err = dnet_cmd_cache_io_lookup_new(cache, st, cmd, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_lookup_new(cache, st, cmd, cmd_stats);
 		case DNET_CMD_DEL_NEW:
-			err = dnet_cmd_cache_io_remove_new(cache, cmd, data, cmd_stats);
-			break;
+			return dnet_cmd_cache_io_remove_new(cache, cmd, data, cmd_stats);
+		default:
+			return -ENOTSUP;
 		}
 	} catch (const std::exception &e) {
-		DNET_LOG_ERROR(n, "{}: {} cache operation failed: {}", dnet_dump_id(&cmd->id),
+		DNET_LOG_ERROR(st->n, "{}: {} cache operation failed: {}", dnet_dump_id(&cmd->id),
 		               dnet_cmd_string(cmd->cmd), e.what());
-		err = -ENOENT;
+		return -ENOENT;
 	}
 
-	return err;
-}
-
-int dnet_cmd_cache_lookup(struct dnet_backend_io *backend,
-                          struct dnet_net_state *st,
-                          struct dnet_cmd *cmd,
-                          struct dnet_cmd_stats *cmd_stats) {
-	struct dnet_node *n = st->n;
-	int err = -ENOTSUP;
-
-	if (!backend->cache) {
-		return -ENOTSUP;
-	}
-
-	auto cache = reinterpret_cast<cache_manager *>(backend->cache);
-
-	try {
-		err = dnet_cmd_cache_io_lookup(backend, cache, st, cmd, cmd_stats);
-	} catch (const std::exception &e) {
-		DNET_LOG_ERROR(n, "{}: {} cache operation failed: {}", dnet_dump_id(&cmd->id),
-		               dnet_cmd_string(cmd->cmd), e.what());
-		err = -ENOENT;
-	}
-
-	return err;
-}
-
-void *dnet_cache_init(struct dnet_node *n, struct dnet_backend_io *backend, const void *config)
-{
-	try {
-		return new cache_manager(backend, n, *reinterpret_cast<const cache_config *>(config));
-	} catch (const std::exception &e) {
-		DNET_LOG_ERROR(n, "Could not create cache: {}", e.what());
-		return nullptr;
-	}
-}
-
-void dnet_cache_cleanup(void *cache)
-{
-	delete reinterpret_cast<cache_manager *>(cache);
 }

--- a/cache/local_session.cpp
+++ b/cache/local_session.cpp
@@ -18,7 +18,12 @@
  */
 
 #include "local_session.h"
+
+#include <blackhole/attribute.hpp>
+
+#include "library/backend.h"
 #include "library/logger.hpp"
+#include "library/protocol.hpp"
 
 using namespace ioremap::elliptics;
 
@@ -34,8 +39,10 @@ using namespace ioremap::elliptics;
 	     &pos->member != (head); 					\
 	     pos = n, n = list_entry(n->member.next, decltype(*n), member))
 
-local_session::local_session(dnet_backend_io *backend, dnet_node *node) : m_backend(backend), m_ioflags(DNET_IO_FLAGS_CACHE), m_cflags(DNET_FLAGS_NOLOCK)
-{
+local_session::local_session(dnet_backend &backend, dnet_node *node)
+: m_backend(backend)
+, m_ioflags(DNET_IO_FLAGS_CACHE)
+, m_cflags(DNET_FLAGS_NOLOCK) {
 	m_state = reinterpret_cast<dnet_net_state *>(malloc(sizeof(dnet_net_state)));
 	if (!m_state)
 		throw std::bad_alloc();
@@ -67,11 +74,6 @@ void local_session::set_cflags(uint64_t flags)
 	m_cflags = flags;
 }
 
-int local_session::backend_id() const
-{
-	return m_backend->backend_id;
-}
-
 data_pointer local_session::read(const dnet_id &id, int *errp)
 {
 	return read(id, NULL, NULL, errp);
@@ -95,8 +97,9 @@ data_pointer local_session::read(const dnet_id &id, uint64_t *user_flags, dnet_t
 	cmd.cmd = DNET_CMD_READ;
 	cmd.flags |= m_cflags;
 	cmd.size = sizeof(io);
+	cmd.backend_id = m_backend.backend_id();
 
-	int err = dnet_process_cmd_raw(m_backend, m_state, &cmd, &io, 0, 0);
+	int err = dnet_process_cmd_raw(m_state, &cmd, &io, 0, 0);
 	if (err) {
 		clear_queue();
 		*errp = err;
@@ -195,8 +198,9 @@ int local_session::write(const dnet_id &id, const char *data, size_t size, uint6
 	cmd.cmd = DNET_CMD_WRITE;
 	cmd.flags |= m_cflags;
 	cmd.size = datap.size();
+	cmd.backend_id = m_backend.backend_id();
 
-	int err = dnet_process_cmd_raw(m_backend, m_state, &cmd, datap.data(), 0, 0);
+	int err = dnet_process_cmd_raw(m_state, &cmd, datap.data(), 0, 0);
 
 	clear_queue(&err);
 
@@ -208,8 +212,9 @@ data_pointer local_session::lookup(const dnet_cmd &tmp_cmd, int *errp)
 	dnet_cmd cmd = tmp_cmd;
 	cmd.flags |= m_cflags;
 	cmd.size = 0;
+	cmd.backend_id = m_backend.backend_id();
 
-	*errp = dnet_process_cmd_raw(m_backend, m_state, &cmd, NULL, 0, 0);
+	*errp = dnet_process_cmd_raw(m_state, &cmd, nullptr, 0, 0);
 
 	if (*errp)
 		return data_pointer();
@@ -235,25 +240,50 @@ data_pointer local_session::lookup(const dnet_cmd &tmp_cmd, int *errp)
 	return data_pointer();
 }
 
-int local_session::remove(const dnet_id &id)
-{
-	dnet_cmd cmd;
-	memset(&cmd, 0, sizeof(cmd));
-
-	cmd.id = id;
-	cmd.cmd = DNET_CMD_DEL;
-	cmd.flags |= m_cflags;
-	cmd.size = sizeof(dnet_io_attr);
-
-	dnet_io_attr io;
+int local_session::remove(const struct dnet_id &id) {
+	struct dnet_io_attr io;
 	memset(&io, 0, sizeof(io));
-	memcpy(io.id, id.id, DNET_ID_SIZE);
 	memcpy(io.parent, id.id, DNET_ID_SIZE);
-	io.flags |= m_ioflags;
+	memcpy(io.id, id.id, DNET_ID_SIZE);
+	io.flags = DNET_IO_FLAGS_SKIP_SENDING;
+	dnet_convert_io_attr(&io);
 
-	int err = dnet_process_cmd_raw(m_backend, m_state, &cmd, &io, 0, 0);
+	struct dnet_cmd cmd;
+	memset(&cmd, 0, sizeof(cmd));
+	cmd.id = id;
+	cmd.size = sizeof(io);
+	cmd.flags = DNET_FLAGS_NOLOCK;
+	cmd.cmd = DNET_CMD_DEL;
+	cmd.backend_id = m_backend.backend_id();
 
-	clear_queue(&err);
+	struct dnet_cmd_stats cmd_stats;
+	memset(&cmd_stats, 0, sizeof(cmd_stats));
+
+	const auto &callbacks = m_backend.callbacks();
+	const int err = callbacks.command_handler(m_state, callbacks.command_private, &cmd, &io, &cmd_stats);
+	DNET_LOG_NOTICE(m_state->n, "{}: local remove: err: {}", dnet_dump_id(&cmd.id), err);
+
+	clear_queue(nullptr);
+	return err;
+}
+
+int local_session::remove_new(const struct dnet_id &id, const ioremap::elliptics::dnet_remove_request &request) {
+	const auto packet = ioremap::elliptics::serialize(request);
+
+	struct dnet_cmd cmd;
+	memset(&cmd, 0, sizeof(struct dnet_cmd));
+	cmd.id = id;
+	cmd.size = packet.size();
+	cmd.flags = DNET_FLAGS_NOLOCK;
+	cmd.cmd = DNET_CMD_DEL_NEW;
+	cmd.backend_id = m_backend.backend_id();
+
+	struct dnet_cmd_stats cmd_stats;
+	memset(&cmd_stats, 0, sizeof(struct dnet_cmd_stats));
+
+	const auto &callbacks = m_backend.callbacks();
+	int err = callbacks.command_handler(m_state, callbacks.command_private, &cmd, packet.data(), &cmd_stats);
+	DNET_LOG_NOTICE(m_state->n, "{}: local remove_new: err: {}", dnet_dump_id(&cmd.id), err);
 
 	return err;
 }

--- a/cache/local_session.h
+++ b/cache/local_session.h
@@ -25,39 +25,45 @@
 
 #include <chrono>
 
-class local_session
-{
-	ELLIPTICS_DISABLE_COPY(local_session)
-	public:
-		local_session(dnet_backend_io *backend, dnet_node *node);
-		~local_session();
+struct dnet_backend;
 
-		void set_ioflags(uint32_t flags);
-		void set_cflags(uint64_t flags);
+namespace ioremap { namespace elliptics {
+class dnet_remove_request;
+}} /* namespace ioremap::elliptics */
 
-		int backend_id() const;
+class local_session {
+	local_session(const local_session&) = delete;
+	local_session &operator =(const local_session &) = delete;
+public:
+	local_session(dnet_backend &backend, dnet_node *node);
+	~local_session();
 
-		ioremap::elliptics::data_pointer read(const dnet_id &id, int *errp);
-		ioremap::elliptics::data_pointer read(const dnet_id &id, uint64_t *user_flags, dnet_time *timestamp, int *errp);
-		int write(const dnet_id &id, const ioremap::elliptics::data_pointer &data);
-		int write(const dnet_id &id, const char *data, size_t size);
-		int write(const dnet_id &id, const char *data, size_t size, uint64_t user_flags, const dnet_time &timestamp);
-		ioremap::elliptics::data_pointer lookup(const dnet_cmd &cmd, int *errp);
-		int remove(const dnet_id &id);
+	void set_ioflags(uint32_t flags);
+	void set_cflags(uint64_t flags);
 
-	private:
-		void clear_queue(int *errp = NULL);
+	ioremap::elliptics::data_pointer read(const dnet_id &id, int *errp);
+	ioremap::elliptics::data_pointer read(const dnet_id &id, uint64_t *user_flags, dnet_time *timestamp, int *errp);
 
-		dnet_backend_io *m_backend;
-		dnet_net_state *m_state;
-		uint32_t m_ioflags;
-		uint64_t m_cflags;
+	int write(const dnet_id &id, const ioremap::elliptics::data_pointer &data);
+	int write(const dnet_id &id, const char *data, size_t size);
+	int write(const dnet_id &id, const char *data, size_t size, uint64_t user_flags, const dnet_time &timestamp);
+
+	ioremap::elliptics::data_pointer lookup(const dnet_cmd &cmd, int *errp);
+
+	int remove(const struct dnet_id &id);
+	int remove_new(const struct dnet_id &id, const ioremap::elliptics::dnet_remove_request &request);
+
+private:
+	void clear_queue(int *errp = nullptr);
+
+	dnet_backend &m_backend;
+	dnet_net_state *m_state;
+	uint32_t m_ioflags;
+	uint64_t m_cflags;
 };
 
-class elliptics_timer
-{
+class elliptics_timer {
 public:
-
 	typedef std::chrono::time_point<std::chrono::system_clock> time_point_t;
 
 	elliptics_timer()

--- a/cache/local_session.h
+++ b/cache/local_session.h
@@ -20,8 +20,7 @@
 #ifndef LOCAL_SESSION_H
 #define LOCAL_SESSION_H
 
-#include "../library/elliptics.h"
-#include "../include/elliptics/session.hpp"
+#include "elliptics/utils.hpp"
 
 #include <chrono>
 

--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -22,6 +22,9 @@
 
 #include <deque>
 
+#include <blackhole/attribute.hpp>
+
+#include "library/backend.h"
 #include "library/request_queue.h"
 #include "library/protocol.hpp"
 
@@ -48,26 +51,30 @@ namespace ioremap { namespace cache {
 
 // public:
 
-slru_cache_t::slru_cache_t(struct dnet_backend_io *backend, struct dnet_node *n,
-	const std::vector<size_t> &cache_pages_max_sizes, unsigned sync_timeout) :
-	m_backend(backend),
-	m_node(n),
-	m_cache_pages_number(cache_pages_max_sizes.size()),
-	m_cache_pages_max_sizes(cache_pages_max_sizes),
-	m_cache_pages_sizes(m_cache_pages_number, 0),
-	m_cache_pages_lru(new lru_list_t[m_cache_pages_number]),
-	m_clear_occured(false),
-	m_sync_timeout(sync_timeout) {
+slru_cache_t::slru_cache_t(struct dnet_node *n,
+                           dnet_backend &backend,
+                           const std::vector<size_t> &cache_pages_max_sizes,
+                           unsigned sync_timeout,
+                           bool &need_exit)
+: m_backend(backend)
+, m_node(n)
+, m_cache_pages_number(cache_pages_max_sizes.size())
+, m_cache_pages_max_sizes(cache_pages_max_sizes)
+, m_cache_pages_sizes(m_cache_pages_number, 0)
+, m_cache_pages_lru(new lru_list_t[m_cache_pages_number])
+, m_clear_occured(false)
+, m_sync_timeout(sync_timeout)
+, m_need_exit{need_exit} {
 	m_lifecheck = std::thread(std::bind(&slru_cache_t::life_check, this));
 }
 
 slru_cache_t::~slru_cache_t() {
 	TIMER_SCOPE("dtor");
-	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: destructing SLRU cache", m_backend->backend_id);
+	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: destructing SLRU cache", m_backend.backend_id());
 	m_lifecheck.join();
-	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: clearing", m_backend->backend_id);
+	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: clearing", m_backend.backend_id());
 	clear();
-	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: destructed", m_backend->backend_id);
+	DNET_LOG_NOTICE(m_node, "cache: disable: backend: {}: destructed", m_backend.backend_id());
 }
 
 write_response_t slru_cache_t::write(dnet_net_state *st, dnet_cmd *cmd, const write_request &request)
@@ -101,7 +108,8 @@ write_response_t slru_cache_t::write(dnet_net_state *st, dnet_cmd *cmd, const wr
 		sync_after_append(guard, false, &*it);
 
 		dnet_cmd_stats stats;
-		int err = m_backend->cb->command_handler(st, m_backend->cb->command_private, cmd, request.request_data, &stats);
+		const auto &callbacks = m_backend.callbacks();
+		int err = callbacks.command_handler(st, callbacks.command_private, cmd, request.request_data, &stats);
 
 		it = populate_from_disk(guard, id, false, &err);
 
@@ -342,20 +350,19 @@ int slru_cache_t::remove(const dnet_cmd *cmd, ioremap::elliptics::dnet_remove_re
 
 		dnet_setup_id(&raw, 0, (unsigned char *)id);
 
+		local_session sess(m_backend, m_node);
+
 		if (cmd->cmd == DNET_CMD_DEL_NEW) {
-			if (it) {
+			if (it)
 				request.ioflags &= ~DNET_IO_FLAGS_CAS_TIMESTAMP;
-			}
-			const auto packet = ioremap::elliptics::serialize(request);
 
 			TIMER_SCOPE("remove.local");
 
-			local_err = dnet_remove_local_new(m_backend, m_node, &raw,
-							  packet.data(), packet.size());
+			local_err = sess.remove_new(raw, request);
 		} else {
 			TIMER_SCOPE("remove.local");
 
-			local_err = dnet_remove_local(m_backend, m_node, &raw);
+			local_err = sess.remove(raw);
 		}
 
 		if (local_err != -ENOENT)
@@ -417,6 +424,10 @@ cache_stats slru_cache_t::get_cache_stats() const {
 }
 
 // private:
+
+bool slru_cache_t::need_exit() const {
+	return m_need_exit || dnet_need_exit(m_node);
+}
 
 
 int slru_cache_t::check_cas(const data_t* it, const dnet_cmd *cmd, const write_request &request) const {
@@ -733,7 +744,7 @@ void slru_cache_t::sync_after_append(elliptics_unique_lock<std::mutex> &guard, b
 
 void slru_cache_t::life_check(void) {
 
-	dnet_set_name("dnet_cache_%zu", m_backend->backend_id);
+	dnet_set_name("dnet_cache_%zu", m_backend.backend_id());
 
 	while (!need_exit()) {
 		{
@@ -788,6 +799,7 @@ void slru_cache_t::life_check(void) {
 				TIMER_SCOPE("life_check.sync_iterate");
 				HANDY_GAUGE_SET("slru_cache.life_check.sync_iterate.element_count",
 				                elements_for_sync.size());
+				auto pool = m_backend.io_pool();
 				for (data_t *elem : elements_for_sync) {
 					if (m_clear_occured)
 						break;
@@ -795,7 +807,7 @@ void slru_cache_t::life_check(void) {
 					memcpy(id.id, elem->id().id, DNET_ID_SIZE);
 
 					TIMER_START("life_check.sync_iterate.dnet_oplock");
-					dnet_oplock(m_backend, &id);
+					dnet_oplock(pool, &id);
 					TIMER_STOP("life_check.sync_iterate.dnet_oplock");
 
 					// sync_element uses local_session which always uses DNET_FLAGS_NOLOCK
@@ -805,14 +817,15 @@ void slru_cache_t::life_check(void) {
 						elem->set_sync_state(data_t::sync_state_t::ERASE_PHASE);
 					}
 
-					dnet_opunlock(m_backend, &id);
+					dnet_opunlock(pool, &id);
 				}
 			}
 
 			{
 				TIMER_SCOPE("life_check.remove_local");
-				for (struct dnet_id &id : remove) {
-				        dnet_remove_local(m_backend, m_node, &id);
+				local_session sess(m_backend, m_node);
+				for (const auto &id : remove) {
+					sess.remove(id);
 				}
 			}
 

--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -850,7 +850,7 @@ void slru_cache_t::life_check(void) {
 			}
 		}
 
-		std::this_thread::sleep_for( std::chrono::milliseconds(1000) );
+		std::this_thread::sleep_for(std::chrono::seconds(1));
 	}
 
 }

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -17,16 +17,21 @@
 #ifndef SLRU_CACHE_HPP
 #define SLRU_CACHE_HPP
 
+#include <thread>
+
 #include "cache.hpp"
+
+class dnet_backend;
 
 namespace ioremap { namespace cache {
 
 class slru_cache_t {
 public:
-	slru_cache_t(struct dnet_backend_io *backend,
-	             struct dnet_node *n,
+	slru_cache_t(struct dnet_node *n,
+	             dnet_backend &backend,
 	             const std::vector<size_t> &cache_pages_max_sizes,
-	             unsigned sync_timeout);
+	             unsigned sync_timeout,
+	             bool &need_exit);
 
 	~slru_cache_t();
 
@@ -43,7 +48,7 @@ public:
 	cache_stats get_cache_stats() const;
 
 private:
-	struct dnet_backend_io *m_backend;
+	dnet_backend &m_backend;
 	struct dnet_node *m_node;
 	std::mutex m_lock;
 	size_t m_cache_pages_number;
@@ -55,13 +60,11 @@ private:
 	mutable cache_stats m_cache_stats;
 	bool m_clear_occured;
 	unsigned m_sync_timeout;
+	const bool &m_need_exit;
 
 	slru_cache_t(const slru_cache_t &) = delete;
 
-	bool need_exit() const
-	{
-		return dnet_need_exit(m_node) || m_backend->need_exit;
-	}
+	bool need_exit() const;
 
 	size_t get_next_page_number(size_t page_number) const {
 		if (page_number == 0) {

--- a/example/config.cpp
+++ b/example/config.cpp
@@ -59,7 +59,7 @@ static blackhole::root_logger_t make_logger(config_data *data) {
 
 	const auto &level = data->logger_level;
 	root.filter([&level](const blackhole::record_t &record) {
-		return log_filter(record, level);
+		return log_filter(record.severity(), level);
 	});
 	return root;
 }

--- a/example/config.hpp
+++ b/example/config.hpp
@@ -41,28 +41,22 @@ struct cache_config {
 
 namespace ioremap { namespace elliptics { namespace config {
 
-class config_error : public std::exception
-{
+class config_error : public std::exception {
 public:
-	explicit config_error()
-	{
-	}
+	explicit config_error() {}
 
-	config_error(const config_error &other) :
-		m_message(other.m_message)
-	{
+	config_error(const config_error &other)
+	: m_message(other.m_message) {
 		m_stream << m_message;
 	}
 
-	config_error &operator =(const config_error &other)
-	{
+	config_error &operator=(const config_error &other) {
 		m_message = other.m_message;
 		m_stream << m_message;
 		return *this;
 	}
 
-	explicit config_error(const std::string &message)
-	{
+	explicit config_error(const std::string &message) {
 		m_stream << message;
 		m_message = message;
 	}
@@ -72,25 +66,22 @@ public:
 	}
 
 	template <typename T>
-	config_error &operator <<(const T &value)
-	{
+	config_error &operator<<(const T &value) {
 		m_stream << value;
 		m_message = m_stream.str();
 		return *this;
 	}
 
-	config_error &operator <<(std::ostream &(*handler)(std::ostream &))
-	{
+	config_error &operator<<(std::ostream &(*handler)(std::ostream &)) {
 		m_stream << handler;
 		m_message = m_stream.str();
 		return *this;
 	}
 
-	virtual ~config_error() throw()
-	{}
+	virtual ~config_error() throw() {}
 
 private:
-	std::stringstream m_stream;
+	std::ostringstream m_stream;
 	std::string m_message;
 };
 

--- a/example/config.hpp
+++ b/example/config.hpp
@@ -1,14 +1,43 @@
-#ifndef CONFIG_HPP
-#define CONFIG_HPP
-#include <kora/config.hpp>
+#pragma once
 
+#include <mutex>
+#include <vector>
+#include <sstream>
+#include <atomic>
+
+#include <boost/optional/optional.hpp>
+
+// TODO: replace by <blackhole/forward.hpp> but currently it leads to compile error
 #include <blackhole/root.hpp>
 
-#include "elliptics/session.hpp"
+#include "elliptics/backends.h"
+#include "library/elliptics.h"
 
+// forward declaration
+namespace kora {
+class config_t;
+class config_parser_t;
+}
 
-#include "library/logger.hpp"
-#include "monitor/monitor.hpp"
+namespace ioremap {
+namespace elliptics {
+class address;
+class backend_wrapper_t;
+}
+namespace monitor {
+struct monitor_config;
+}}
+
+namespace ioremap { namespace cache {
+struct cache_config {
+	size_t			size;
+	size_t			count;
+	unsigned		sync_timeout;
+	std::vector<size_t>	pages_proportions;
+
+	static cache_config parse(const kora::config_t &cache);
+};
+}} /* namespace ioremap::cache */
 
 namespace ioremap { namespace elliptics { namespace config {
 
@@ -38,8 +67,7 @@ public:
 		m_message = message;
 	}
 
-	const char *what() const ELLIPTICS_NOEXCEPT
-	{
+	const char *what() const noexcept {
 		return m_message.c_str();
 	}
 
@@ -66,35 +94,99 @@ private:
 	std::string m_message;
 };
 
+struct io_pool_config {
+	int io_thread_num;
+	int nonblocking_io_thread_num;
+};
+
+struct config_data;
+struct backend_config {
+	backend_config(const config_data &data, const kora::config_t &config);
+	backend_config(const backend_config &) = delete;
+	backend_config &operator=(const backend_config &) = delete;
+
+	// raw config as it presented in config file
+	const std::string				raw_config;
+
+	const uint32_t					backend_id;
+	const uint32_t					group_id;
+	// path to history directory where ids file is stored
+	const std::string				history;
+
+	// used only at node startup and means that the backend should be enabled at startup
+	const bool					enable_at_start;
+	// if true backend after enabling backend will be in read-only mode
+	const bool					read_only_at_start;
+
+	// io_pool options
+	// id of shared io pool
+	const std::string				pool_id;
+	// configuration for individual io pool
+	const io_pool_config				pool_config;
+
+	// timeout used for dropping request stuck in a io pool's queue
+	const uint64_t					queue_timeout;
+
+	const boost::optional<cache::cache_config>	cache_config;
+
+	dnet_config_backend				config_backend;
+
+private:
+	// buffer for backend-specific dnet_config_backend::data.
+	std::vector<char>				config_backend_buffer;
+};
+
 struct config_data : public dnet_config_data {
-	config_data();
+	config_data(std::string path);
 
 	std::shared_ptr<kora::config_parser_t> parse_config();
 
+	// reset logger to reopen log file
 	void reset_logger();
 
-	std::string					config_path;
-	std::mutex					parser_mutex;
-	std::shared_ptr<kora::config_parser_t>		parser;
-	dnet_time					config_timestamp;
-	dnet_backend_info_manager			backends_guard;
+	// get actual backend's config with re-parsing config file if it was updated
+	std::shared_ptr<backend_config> get_backend_config(uint32_t backend_id);
+
+	// load all backends presented in @backends
+	void parse_backends(const kora::config_t &backends);
+
+	// get actual io pool's config with re-parsing config file if it was updated
+	io_pool_config get_io_pool_config(const std::string &pool_id);
+
+public:
+	 // logger section of config file
 	std::string					logger_value;
 	std::atomic<dnet_log_level>			logger_level;
+	// root logger is needed for re-opening log file
 	std::unique_ptr<blackhole::root_logger_t>	root_logger;
+	// common logger is used by default for all logs
 	std::unique_ptr<backend_wrapper_t>		logger;
+	// addresses of remote nodes
 	std::vector<address>				remotes;
-	std::unique_ptr<cache::cache_config>		cache_config;
+	boost::optional<cache::cache_config>		cache_config;
+	// TODO: replace std::unique_ptr by std::optional or boost::optional
 	std::unique_ptr<monitor::monitor_config>	monitor_config;
+	// timeout used for dropping request stuck in a io pool's queue
 	uint64_t					queue_timeout;
+
+	bool						daemon_mode;
+
+	bool						parallel_start;
+	// initial backends' configs used only at startup to validate and run enabled backends
+	std::vector<std::shared_ptr<backend_config>>	backends;
+
+private:
+	// path to config file
+	const std::string				m_config_path;
+	// timestamp of parsed config file
+	dnet_time					m_config_timestamp;
+	std::mutex					m_parser_mutex;
+	std::shared_ptr<kora::config_parser_t>		m_parser;
 };
 
-std::shared_ptr<dnet_backend_info> dnet_parse_backend(config_data *data, uint32_t backend_id, const kora::config_t &backend);
+}}} /* namespace ioremap::elliptics::config */
 
-/*
- * Parse and return value of "queue_timeout" field of @options.
- */
-uint64_t parse_queue_timeout(const kora::config_t &options);
-
-} } } // namespace ioremap::elliptics::config
-
-#endif // CONFIG_HPP
+static inline ioremap::elliptics::config::config_data *dnet_node_get_config_data(struct dnet_node *node) {
+	using ioremap::elliptics::config::config_data;
+	return static_cast<config_data *>(node->config_data);
+}

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1569,7 +1569,7 @@ static int dnet_blob_config_init(struct dnet_config_backend *b, enum dnet_log_le
 	if (err)
 		goto err_out_last_read_lock_destroy;
 
-	eblob_set_trace_id_function(&dnet_node_get_trace_bit);
+	eblob_set_trace_id_function(&dnet_logger_get_trace_bit);
 
 	c->vm_total = st.vm_total * st.vm_total * 1024 * 1024;
 

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1619,7 +1619,10 @@ static void dnet_blob_config_cleanup(struct dnet_config_backend *b)
 		eblob_backend_cleanup(c);
 
 	free(c->data.file);
+	c->data.file = NULL;
+
 	free(c->data.chunks_dir);
+	c->data.chunks_dir = NULL;
 }
 
 static void dnet_blob_set_verbosity(struct dnet_config_backend *b, enum dnet_log_level level) {

--- a/include/elliptics/backends.h
+++ b/include/elliptics/backends.h
@@ -131,9 +131,6 @@ int dnet_ext_hdr_write(const struct dnet_ext_list_hdr *ehdr, int fd, uint64_t of
  */
 struct dnet_config_backend *dnet_eblob_backend_info(void);
 
-int dnet_eblob_backend_init(void);
-void dnet_eblob_backend_exit(void);
-
 int backend_storage_size(struct dnet_config_backend *b, const char *root);
 
 #ifdef __cplusplus

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -125,7 +125,6 @@ enum dnet_backend_command {
 };
 
 enum dnet_backend_state {
-	DNET_BACKEND_UNITIALIZED = -1,
 	DNET_BACKEND_DISABLED = 0,
 	DNET_BACKEND_ENABLED,
 	DNET_BACKEND_ACTIVATING,

--- a/include/elliptics/packet.h
+++ b/include/elliptics/packet.h
@@ -105,7 +105,7 @@ enum dnet_commands {
 #define DNET_MONITOR_CACHE		(1<<0)				/* cache statistics */
 #define DNET_MONITOR_IO			(1<<1)				/* IO queue statistics */
 #define DNET_MONITOR_COMMANDS		(1<<2)				/* commands statistics */
-#define DNET_MONITOR_UNUSED		(1<<3)
+#define DNET_MONITOR_UNUSED		(1<<3)				/* deprecated category, should not be used */
 #define DNET_MONITOR_BACKEND		(1<<4)				/* backend statistics */
 #define DNET_MONITOR_STATS		(1<<5)				/* statistics gathered by handystats */
 #define DNET_MONITOR_PROCFS		(1<<6)				/* virtual memory statistics */

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -1,18 +1,164 @@
-#include "elliptics.h"
-#include "monitor/monitor.hpp"
-#include "example/config.hpp"
-#include "bindings/cpp/functional_p.h"
-#include "bindings/cpp/session_internals.hpp"
-#include "library/logger.hpp"
-#include "library/protocol.hpp"
+#include "backend.h"
 
+#include <fcntl.h>
 #include <fstream>
 #include <memory>
 
-#include <fcntl.h>
+#include <blackhole/wrapper.hpp>
 
-static int dnet_ids_generate(struct dnet_node *n, const char *file, unsigned long long storage_free)
-{
+#include "bindings/cpp/functional_p.h"
+#include "bindings/cpp/session_internals.hpp"
+#include "cache/cache.hpp"
+#include "example/config.hpp"
+#include "library/logger.hpp"
+#include "library/protocol.hpp"
+#include "library/request_queue.h"
+#include "library/route.h"
+#include "monitor/io_stat_provider.hpp"
+#include "monitor/monitor.hpp"
+
+// @dnet_io_pools_manager is responsible for storing and providing access to shared io pools
+class dnet_io_pools_manager {
+public:
+	dnet_io_pools_manager(struct dnet_node *node)
+	: m_node(node) {}
+
+	// return io pool with @pool_id
+	std::shared_ptr<struct dnet_io_pool> get(const std::string &pool_id);
+	// check and stop io pool with @pool_id if no backends are attached to it.
+	// should be called whenever backend is decided to be detached from io pool.
+	int detach(const std::string &pool_id);
+	// fill @value with all shared io pools' statistics
+	void statistics(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator);
+	// add to @queue_size and @threads_count all shared io pools' queues' sizes and number of threads.
+	void check(uint64_t &queue_size, uint64_t threads_count);
+
+private:
+	struct dnet_node							*m_node;
+
+	boost::shared_mutex							m_pools_mutex;
+	std::unordered_map<std::string, std::shared_ptr<struct dnet_io_pool>>	m_pools;
+};
+
+// create (initialize and run) io pool with @pool_id and @config
+static std::shared_ptr<struct dnet_io_pool> create_io_pool(struct dnet_node *node,
+                                                           const std::string &pool_id,
+                                                           const ioremap::elliptics::config::io_pool_config &config) {
+	auto pool = std::make_shared<struct dnet_io_pool>();
+	memset(pool.get(), 0, sizeof(*pool.get()));
+
+	int err = dnet_work_pool_place_init(&pool->recv_pool);
+	if (err) {
+		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to initialize blocking pool: {} [{}]",
+		               pool_id, strerror(-err), err);
+		return nullptr;
+	}
+
+	err = dnet_work_pool_alloc(&pool->recv_pool, node, config.io_thread_num, DNET_WORK_IO_MODE_BLOCKING,
+	                           pool_id.c_str(), dnet_io_process);
+	if (err) {
+		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to allocate blocking pool: {} [{}]",
+		               pool_id, strerror(-err), err);
+		dnet_work_pool_place_cleanup(&pool->recv_pool);
+		return nullptr;
+	}
+
+	err = dnet_work_pool_place_init(&pool->recv_pool_nb);
+	if (err) {
+		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to initialize nonblocking pool: {} [{}]",
+		               pool_id, strerror(-err), err);
+		dnet_work_pool_exit(&pool->recv_pool);
+		dnet_work_pool_place_cleanup(&pool->recv_pool);
+		return nullptr;
+	}
+
+	err = dnet_work_pool_alloc(&pool->recv_pool_nb, node, config.nonblocking_io_thread_num,
+	                           DNET_WORK_IO_MODE_NONBLOCKING, pool_id.c_str(), dnet_io_process);
+	if (err) {
+		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to allocate nonblocking pool: {} [{}]",
+		               pool_id, strerror(-err), err);
+		dnet_work_pool_place_cleanup(&pool->recv_pool_nb);
+		dnet_work_pool_exit(&pool->recv_pool);
+		dnet_work_pool_place_cleanup(&pool->recv_pool);
+		return nullptr;
+	}
+
+	DNET_LOG_INFO(node, "create_io_pool(pool_id: {}): pool was successfully started", pool_id);
+
+	return std::move(pool);
+}
+
+static void stop_io_pool(struct dnet_node *node,
+                         std::shared_ptr<struct dnet_io_pool> pool,
+                         const std::string &pool_id) {
+	DNET_LOG_INFO(node, "stop_io_pool(pool_id: {}): stopping the pool", pool_id);
+
+	pool->recv_pool.pool->need_exit = 1;
+	pool->recv_pool_nb.pool->need_exit = 1;
+
+	// notify all threads to make them exit
+	pool->recv_pool.pool->request_queue->notify_all();
+	pool->recv_pool_nb.pool->request_queue->notify_all();
+
+	dnet_work_pool_exit(&pool->recv_pool);
+	dnet_work_pool_exit(&pool->recv_pool_nb);
+
+	DNET_LOG_INFO(node, "stop_io_pool(pool_id: {}): the pool has been stopped", pool_id);
+}
+
+std::shared_ptr<struct dnet_io_pool> dnet_io_pools_manager::get(const std::string &pool_id) {
+	boost::unique_lock<boost::shared_mutex> guard(m_pools_mutex);
+	auto it = m_pools.find(pool_id);
+	if (it != m_pools.end())
+		return it->second;
+
+	const auto pool_config = dnet_node_get_config_data(m_node)->get_io_pool_config(pool_id);
+	auto pool = create_io_pool(m_node, pool_id, pool_config);
+	m_pools.emplace(pool_id, pool);
+
+	return std::move(pool);
+}
+
+int dnet_io_pools_manager::detach(const std::string &pool_id) {
+	boost::unique_lock<boost::shared_mutex> guard(m_pools_mutex);
+	auto pool_it = m_pools.find(pool_id);
+	if (pool_it == m_pools.end()) {
+		DNET_LOG_ERROR(m_node, "dnet_io_pools_manager::detach(pool_id: {}): there is no such pool", pool_id);
+		return -ENOENT;
+	}
+
+	auto &pool = pool_it->second;
+
+	// stop @pool without any backend attached to it
+	if (pool.use_count() == 1) {
+		stop_io_pool(m_node, pool, pool_id);
+		m_pools.erase(pool_it);
+	}
+
+	return 0;
+}
+
+void dnet_io_pools_manager::statistics(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	boost::shared_lock<boost::shared_mutex> guard(m_pools_mutex);
+	for (auto &item : m_pools) {
+		const auto &pool_id = item.first;
+		const auto &io_pool = item.second;
+
+		rapidjson::Value pool(rapidjson::kObjectType);
+		ioremap::monitor::dump_io_pool_stats(*io_pool, pool, allocator);
+		value.AddMember(pool_id.c_str(), allocator, pool, allocator);
+	}
+}
+
+void dnet_io_pools_manager::check(uint64_t &queue_size, uint64_t threads_count) {
+	boost::shared_lock<boost::shared_mutex> guard(m_pools_mutex);
+	for (auto &item : m_pools) {
+		const auto &io_pool = item.second;
+		dnet_check_io_pool(io_pool.get(), &queue_size, &threads_count);
+	}
+}
+
+static int dnet_ids_generate(struct dnet_node *n, const char *file, unsigned long long storage_free) {
 	const unsigned long long size_per_id = 100 * 1024 * 1024 * 1024ULL;
 	const size_t num = storage_free / size_per_id + 1;
 	dnet_raw_id tmp;
@@ -58,16 +204,19 @@ err_out_exit:
 	return err;
 }
 
-static struct dnet_raw_id *dnet_ids_init(struct dnet_node *n, const char *hdir, int *id_num,
-		unsigned long long storage_free, struct dnet_addr *cfg_addrs, size_t backend_id)
-{
+static struct dnet_raw_id *dnet_ids_init(struct dnet_node *n,
+                                         const std::string &hdir,
+                                         int *id_num,
+                                         unsigned long long storage_free,
+                                         struct dnet_addr *cfg_addrs,
+                                         uint32_t backend_id) {
 	int fd, err, num;
 	const char *file = "ids";
-	char path[strlen(hdir) + 1 + strlen(file) + 1]; /* / + null-byte */
+	char path[hdir.size() + 1 + strlen(file) + 1]; /* / + null-byte */
 	struct stat st;
 	struct dnet_raw_id *ids;
 
-	snprintf(path, sizeof(path), "%s/%s", hdir, file);
+	snprintf(path, sizeof(path), "%s/%s", hdir.c_str(), file);
 
 again:
 	fd = open(path, O_RDONLY | O_CLOEXEC);
@@ -76,6 +225,7 @@ again:
 		if (err == -ENOENT) {
 			if (n->flags & DNET_CFG_KEEPS_IDS_IN_CLUSTER)
 				err = dnet_ids_update(n, 1, path, cfg_addrs, backend_id);
+
 			if (err)
 				err = dnet_ids_generate(n, path, storage_free);
 
@@ -132,60 +282,10 @@ err_out_free:
 err_out_close:
 	close(fd);
 err_out_exit:
-	return NULL;
+	return nullptr;
 }
 
-static int dnet_backend_io_init(struct dnet_node *n, struct dnet_backend_io *io,
-		int io_thread_num, int nonblocking_io_thread_num)
-{
-	int err;
-
-	err = dnet_backend_command_stats_init(io);
-	if (err) {
-		DNET_LOG_ERROR(n, "dnet_backend_io_init: backend: {}, failed to allocate command stat structure: {}",
-		               io->backend_id, err);
-		goto err_out_exit;
-	}
-
-	err = dnet_work_pool_alloc(&io->pool.recv_pool, n, io,
-			io_thread_num, DNET_WORK_IO_MODE_BLOCKING,
-			dnet_io_process);
-	if (err) {
-		goto err_out_command_stats_cleanup;
-	}
-
-	err = dnet_work_pool_alloc(&io->pool.recv_pool_nb, n, io,
-			nonblocking_io_thread_num, DNET_WORK_IO_MODE_NONBLOCKING,
-			dnet_io_process);
-	if (err) {
-		err = -ENOMEM;
-		goto err_out_free_recv_pool;
-	}
-
-	return 0;
-
-err_out_free_recv_pool:
-	n->need_exit = 1;
-	dnet_work_pool_exit(&io->pool.recv_pool);
-err_out_command_stats_cleanup:
-	dnet_backend_command_stats_cleanup(io);
-err_out_exit:
-	return err;
-}
-
-static void dnet_backend_io_cleanup(struct dnet_node *n, struct dnet_backend_io *io)
-{
-	(void) n;
-
-	dnet_work_pool_exit(&io->pool.recv_pool);
-	dnet_work_pool_exit(&io->pool.recv_pool_nb);
-	dnet_backend_command_stats_cleanup(io);
-
-	DNET_LOG_NOTICE(n, "dnet_backend_io_cleanup: backend: {}", io->backend_id);
-}
-
-static const char *elapsed(const dnet_time &start)
-{
+static const char *elapsed(const dnet_time &start) {
 	static __thread char buffer[64];
 	dnet_time end;
 	dnet_current_time(&end);
@@ -198,411 +298,70 @@ static const char *elapsed(const dnet_time &start)
 	return buffer;
 }
 
-static int dnet_backend_init(struct dnet_node *node, size_t backend_id)
-{
-	int ids_num;
-	struct dnet_raw_id *ids;
 
-	auto backend = node->config_data->backends->get_backend(backend_id);
-	if (!backend) {
-		DNET_LOG_ERROR(node, "backend_init: backend: {}, invalid backend id", backend_id);
-		return -EINVAL;
-	}
-
-	dnet_time start;
-	dnet_current_time(&start);
-
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		if (backend->state != DNET_BACKEND_DISABLED) {
-			DNET_LOG_ERROR(
-			        node, "backend_init: backend: {}, trying to activate not disabled backend, elapsed: {}",
-			        backend_id, elapsed(start));
-			switch (backend->state) {
-				case DNET_BACKEND_ENABLED:
-					return -EALREADY;
-				case DNET_BACKEND_ACTIVATING:
-					return -EINPROGRESS;
-				case DNET_BACKEND_DEACTIVATING:
-					return -EAGAIN;
-				case DNET_BACKEND_UNITIALIZED:
-				default:
-					return -EINVAL;
-			}
-		}
-		backend->state = DNET_BACKEND_ACTIVATING;
-	}
-
-	DNET_LOG_INFO(node, "backend_init: backend: {}, initializing", backend_id);
-
-	int err;
-	dnet_backend_io *backend_io;
-
-	try {
-		using namespace ioremap::elliptics::config;
-		auto &data = *static_cast<config_data *>(node->config_data);
-		auto parser = data.parse_config();
-		auto cfg = parser->root();
-		const auto backends_config = cfg["backends"];
-		bool found = false;
-
-		for (size_t index = 0; index < backends_config.size(); ++index) {
-			const auto backend_config = backends_config[index];
-			const uint32_t config_backend_id = backend_config.at<uint32_t>("backend_id");
-			if (backend_id == config_backend_id) {
-				backend->parse(&data, backend_config);
-				found = true;
-				break;
-			}
-		}
-
-		if (!found) {
-			err = -EBADF;
-			DNET_LOG_ERROR(node, "backend_init: backend: {}, have not found backend section in "
-			                     "configuration file, elapsed: {}",
-			               backend_id, elapsed(start));
-			goto err_out_exit;
-		}
-	} catch (std::bad_alloc &) {
-		err = -ENOMEM;
-		DNET_LOG_ERROR(node, "backend_init: backend: {}, failed as not enough memory, elapsed: {}", backend_id,
-		               elapsed(start));
-		goto err_out_exit;
-	} catch (std::exception &exc) {
-		DNET_LOG_ERROR(node, "backend_init: backend: {}, failed to read configuration file: {}, elapsed: {}",
-		               backend_id, exc.what(), elapsed(start));
-		err = -EBADF;
-		goto err_out_exit;
-	}
-
-	backend->config = backend->config_template;
-	backend->data.assign(backend->data.size(), '\0');
-	backend->config.data = backend->data.data();
-	backend->config.log = backend->log.get();
-
-	backend_io = dnet_get_backend_io(node->io, backend_id);
-	backend_io->need_exit = 0;
-	backend_io->read_only = backend->read_only_at_start;
-	backend_io->queue_timeout = backend->queue_timeout;
-
-	for (auto it = backend->options.begin(); it != backend->options.end(); ++it) {
-		const dnet_backend_config_entry &entry = *it;
-		entry.entry->callback(&backend->config, entry.entry->key, entry.value_template.data());
-	}
-
-	err = backend->config.init(&backend->config, dnet_node_get_verbosity(node));
-	if (err) {
-		DNET_LOG_ERROR(node, "backend_init: backend: {}, failed to init backend: {}, elapsed: {}", backend_id,
-		               err, elapsed(start));
-		goto err_out_exit;
-	}
-
-	backend_io->cb = &backend->config.cb;
-
-	err = dnet_backend_io_init(node, backend_io, backend->io_thread_num, backend->nonblocking_io_thread_num);
-	if (err) {
-		DNET_LOG_ERROR(node, "backend_init: backend: {}, failed to init io pool, err: {}, elapsed: {}",
-		               backend_id, err, elapsed(start));
-		goto err_out_backend_cleanup;
-	}
-
-	if (backend->cache_config) {
-		backend_io->cache = backend->cache = dnet_cache_init(node, backend_io, backend->cache_config.get());
-		if (!backend->cache) {
-			err = -ENOMEM;
-			DNET_LOG_ERROR(node, "backend_init: backend: {}, failed to init cache, err: {}, elapsed: {}",
-			               backend_id, err, elapsed(start));
-			goto err_out_backend_io_cleanup;
-		}
-	}
-
-	ids_num = 0;
-	ids = dnet_ids_init(node, backend->history.c_str(), &ids_num, backend->config.storage_free, node->addrs, backend_id);
-	if (ids == NULL) {
-		err = -EINVAL;
-		DNET_LOG_ERROR(
-		        node,
-		        "backend_init: backend: {}, history path: {}, failed to initialize ids, elapsed: {}: {} [{}]",
-		        backend_id, backend->history, elapsed(start), strerror(-err), err);
-		goto err_out_cache_cleanup;
-	}
-	err = dnet_route_list_enable_backend(node->route, backend_id, backend->group, ids, ids_num);
-	free(ids);
-
-	if (err) {
-		DNET_LOG_ERROR(node,
-		               "backend_init: backend: {}, failed to add backend to route list, err: {}, elapsed: {}",
-		               backend_id, err, elapsed(start));
-		goto err_out_cache_cleanup;
-	}
-
-	DNET_LOG_INFO(node, "backend_init: backend: {}, initialized, elapsed: {}", backend_id, elapsed(start));
-
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		dnet_current_time(&backend->last_start);
-		backend->last_start_err = 0;
-		backend->state = DNET_BACKEND_ENABLED;
-	}
-	return 0;
-
-	dnet_route_list_disable_backend(node->route, backend_id);
-err_out_cache_cleanup:
-	if (backend->cache) {
-		/* Set need_exit to stop cache's threads */
-		backend_io->need_exit = 1;
-		dnet_cache_cleanup(backend->cache);
-		backend->cache = NULL;
-		backend_io->cache = NULL;
-	}
-err_out_backend_io_cleanup:
-	backend_io->need_exit = 1;
-	dnet_backend_io_cleanup(node, backend_io);
-	backend_io->cb = nullptr;
-err_out_backend_cleanup:
-	backend->config.cleanup(&backend->config);
-err_out_exit:
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		dnet_current_time(&backend->last_start);
-		backend->last_start_err = err;
-		backend->state = DNET_BACKEND_DISABLED;
-	}
-	return err;
+uint32_t dnet_backend_get_backend_id(struct dnet_backend *backend) {
+	return backend->backend_id();
 }
 
-static int dnet_backend_cleanup(struct dnet_node *node, size_t backend_id)
-{
-	auto backend = node->config_data->backends->get_backend(backend_id);
-	if (!backend) {
-		return -EINVAL;
-	}
-
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		if (backend->state != DNET_BACKEND_ENABLED) {
-			DNET_LOG_ERROR(node, "backend_cleanup: backend: {}, trying to destroy not activated backend",
-			               backend_id);
-			switch (backend->state) {
-				case DNET_BACKEND_DISABLED:
-					return -EALREADY;
-				case DNET_BACKEND_DEACTIVATING:
-					return -EINPROGRESS;
-				case DNET_BACKEND_ACTIVATING:
-					return -EAGAIN;
-				case DNET_BACKEND_UNITIALIZED:
-				default:
-					return -EINVAL;
-			}
-		}
-		backend->state = DNET_BACKEND_DEACTIVATING;
-	}
-
-	DNET_LOG_INFO(node, "backend_cleanup: backend: {}, destroying", backend_id);
-
-	if (node->route)
-		dnet_route_list_disable_backend(node->route, backend_id);
-
-	dnet_backend_io *backend_io = node->io ? dnet_get_backend_io(node->io, backend_id) : nullptr;
-
-	// set @need_exit to true to force cache lifecheck thread to exit and slru cache to sync all elements to backend
-	// this also leads to IO threads to stop, but since we already removed itself from route table,
-	// and cache syncs data to backend either in lifecheck thread or in destructor context,
-	// it is safe to set @need_exit early
-	if (backend_io)
-		backend_io->need_exit = 1;
-
-	DNET_LOG_INFO(node, "backend_cleanup: backend: {}: cleaning cache", backend_id);
-	dnet_cache_cleanup(backend->cache);
-	backend->cache = NULL;
-
-	DNET_LOG_INFO(node, "backend_cleanup: backend: {}: cleaning io: {:p}", backend_id, (void *)backend_io);
-	if (backend_io) {
-		dnet_backend_io_cleanup(node, backend_io);
-		backend_io->cb = NULL;
-	}
-
-	backend->config.cleanup(&backend->config);
-	memset(&backend->config.cb, 0, sizeof(backend->config.cb));
-
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		backend->state = DNET_BACKEND_DISABLED;
-	}
-
-	DNET_LOG_INFO(node, "backend_cleanup: backend: {}, destroyed", backend_id);
-
-	return 0;
+int dnet_backend_read_only(struct dnet_backend *backend) {
+	return backend->read_only() ? 1 : 0;
 }
 
-/* Disable and remove backend */
-static int dnet_backend_remove(struct dnet_node *node, size_t backend_id) {
-	const int err = dnet_backend_cleanup(node, backend_id);
-	if (err && err != -EALREADY) {
-		DNET_LOG_INFO(node, "backend_remove: backend: {}, failed to disable backend: {} [{}]", backend_id,
-		              strerror(-err), err);
-		return err;
-	}
-
-	node->config_data->backends->remove_backend(backend_id);
-
-	DNET_LOG_INFO(node, "backend_remove: backend: {}, removed", backend_id);
-	return 0;
+dnet_backend_callbacks *dnet_backend_get_callbacks(struct dnet_backend *backend) {
+	return &backend->callbacks();
 }
 
+void dnet_backend_sleep_delay(struct dnet_backend *backend) {
+	if (!backend || !backend->delay())
+		return;
 
-int dnet_backend_create(struct dnet_node *node, size_t backend_id)
-{
-	auto backends = node->config_data->backends;
-	auto backend = backends->get_backend(backend_id);
-	if (backend)
-		return 0;
+	std::this_thread::sleep_for(std::chrono::milliseconds(backend->delay()));
+}
 
-	try {
-		using namespace ioremap::elliptics::config;
-		auto data = static_cast<config_data *>(node->config_data);
-		auto parser = data->parse_config();
-		auto cfg = parser->root();
-		const auto backends_config = cfg["backends"];
-
-		for (size_t index = 0; index < backends_config.size(); ++index) {
-			const auto backend_config = backends_config[index];
-
-			if (backend_id == backend_config.at<uint32_t>("backend_id")) {
-				backend = dnet_parse_backend(data, backend_id, backend_config);
-			}
-		}
-	} catch (std::bad_alloc &) {
-		DNET_LOG_ERROR(node, "backend_create: backend: {}, failed as not enough memory", backend_id);
-		return -ENOMEM;
-	} catch (std::exception &exc) {
-		DNET_LOG_ERROR(node, "backend_create: backend: {}, failed to read configuration file: {}", backend_id,
-		               exc.what());
-		return -EBADF;
-	}
-
+void dnet_backend_unlock_state(struct dnet_backend *backend) {
 	if (!backend)
-		return -ENOENT;
+		return;
 
-	int err = dnet_server_backend_init(node, backend_id);
-	if (!err) {
-		backends->add_backend(backend);
-	}
-
-	return err;
+	backend->state_mutex().unlock_shared();
 }
 
-int dnet_backend_init_all(struct dnet_node *node)
-{
-	int err = 1;
-	bool all_ok = true;
-
-	auto backends = node->config_data->backends;
-	using namespace ioremap::elliptics::config;
-	auto &data = *static_cast<config_data *>(node->config_data);
-	auto parser = data.parse_config();
-	auto cfg = parser->root();
-	const auto backends_config = cfg["backends"];
-
-	if (node->config_data->parallel_start) {
-		try {
-			using ioremap::elliptics::session;
-			using ioremap::elliptics::async_backend_control_result;
-
-			session sess(node);
-			sess.set_exceptions_policy(session::no_exceptions);
-			sess.set_timeout(std::numeric_limits<unsigned>::max() / 2);
-
-			session clean_sess = sess.clean_clone();
-
-			std::vector<async_backend_control_result> results;
-
-
-			for (size_t index = 0; index < backends_config.size(); ++index) {
-				const auto backend_config = backends_config[index];
-				const uint32_t backend_id = backend_config.at<uint32_t>("backend_id");
-				auto backend = backends->get_backend(backend_id);
-				if (!backend->enable_at_start) {
-					backend->parse(&data, backend_config);
-					continue;
-				}
-
-				results.emplace_back(clean_sess.enable_backend(node->st->addr, backend_id));
-			}
-
-			async_backend_control_result result =
-				ioremap::elliptics::aggregated(sess, results.begin(), results.end());
-			result.wait();
-
-			err = result.error().code();
-		} catch (std::bad_alloc &) {
-			return -ENOMEM;
-		}
-	} else {
-		for (size_t index = 0; index < backends_config.size(); ++index) {
-			const auto backend_config = backends_config[index];
-			const uint32_t backend_id = backend_config.at<uint32_t>("backend_id");
-			auto backend = backends->get_backend(backend_id);
-			if (!backend->enable_at_start) {
-				backend->parse(&data, backend_config);
-				continue;
-			}
-
-			int tmp = dnet_backend_init(node, backend_id);
-			if (!tmp) {
-				err = 0;
-			} else if (err == 1) {
-				err = tmp;
-				all_ok = false;
-			}
-		}
-	}
-
-	if (all_ok) {
-		err = 0;
-	} else if (err == 1) {
-		err = -EINVAL;
-	}
-
-	DNET_LOG(node, err ? DNET_LOG_ERROR : DNET_LOG_NOTICE,
-	         "backend_init_all: finished initializing all backends: {}", err);
-
-	return err;
-}
-
-void dnet_backend_cleanup_all(struct dnet_node *node) {
-	for (auto backend : node->config_data->backends->get_all_backends()) {
-		if (backend->state != DNET_BACKEND_DISABLED)
-			dnet_backend_cleanup(node, backend->backend_id);
-	}
-}
-
-static int dnet_backend_set_ids(dnet_node *node, uint32_t backend_id, dnet_raw_id *ids, uint32_t ids_count)
-{
-	auto backend = node->config_data->backends->get_backend(backend_id);
-	if (!backend) {
+int dnet_backends_init_all(struct dnet_node *node) {
+	if (!node || !node->io || !node->io->backends_manager)
 		return -EINVAL;
-	}
 
-	if (backend->history.empty()) {
-		DNET_LOG_ERROR(
-		        node,
-		        "backend_set_ids: backend_id: {}, failed to open temporary ids file: history is not specified",
-		        backend_id);
+	return node->io->backends_manager->init_all(dnet_node_get_config_data(node)->parallel_start);
+}
+
+void dnet_backends_cleanup_all(struct dnet_node *node) {
+	if (!node || !node->io || !node->io->backends_manager)
+		return;
+
+	node->io->backends_manager->clear();
+}
+
+static int dnet_backend_set_ids(dnet_node *node,
+                                dnet_backend &backend,
+                                std::shared_ptr<backend_config> config,
+                                dnet_raw_id *ids,
+                                uint32_t ids_count) {
+	if (config->history.empty()) {
+		DNET_LOG_ERROR(node, "backend_set_ids: backend_id: {}, failed to open temporary ids file: "
+		                     "history is not specified",
+		               backend.backend_id());
 		return -EINVAL;
 	}
 
 	char tmp_ids[1024];
 	char target_ids[1024];
-	snprintf(tmp_ids, sizeof(tmp_ids), "%s/ids_%08x%08x", backend->history.c_str(), rand(), rand());
-	snprintf(target_ids, sizeof(target_ids), "%s/ids", backend->history.c_str());
+	snprintf(tmp_ids, sizeof(tmp_ids), "%s/ids_%08x%08x", config->history.c_str(), rand(), rand());
+	snprintf(target_ids, sizeof(target_ids), "%s/ids", config->history.c_str());
 	int err = 0;
 
 	std::ofstream out(tmp_ids, std::ofstream::binary | std::ofstream::trunc);
 	if (!out) {
 		err = -errno;
 		DNET_LOG_ERROR(node, "backend_set_ids: backend_id: {}, failed to open temporary ids file: {}, err: {}",
-		               backend_id, tmp_ids, err);
+		               backend.backend_id(), tmp_ids, err);
 		return err;
 	}
 
@@ -616,25 +375,25 @@ static int dnet_backend_set_ids(dnet_node *node, uint32_t backend_id, dnet_raw_i
 			DNET_LOG_ERROR(
 			        node,
 			        "backend_set_ids: backend_id: {}, failed to write ids to temporary file: {}, err: {}",
-			        backend_id, tmp_ids, err);
+			        backend.backend_id(), tmp_ids, err);
 		} else {
-
 			if (!err) {
-				std::lock_guard<std::mutex> guard(*backend->state_mutex);
-				switch (backend->state) {
-					case DNET_BACKEND_ENABLED:
-						err = std::rename(tmp_ids, target_ids);
-						if (err)
-							break;
-						err = dnet_route_list_enable_backend(node->route,
-								backend_id, backend->group, ids, ids_count);
+				boost::shared_lock<boost::shared_mutex> guard(backend.state_mutex());
+				switch (backend.state()) {
+				case DNET_BACKEND_ENABLED:
+					err = std::rename(tmp_ids, target_ids);
+					if (err) {
 						break;
-					case DNET_BACKEND_DISABLED:
-						err = std::rename(tmp_ids, target_ids);
-						break;
-					default:
-						err = -EBUSY;
-						break;
+					}
+					err = dnet_route_list_enable_backend(node->route, backend.backend_id(),
+					                                     backend.group_id(), ids, ids_count);
+					break;
+				case DNET_BACKEND_DISABLED:
+					err = std::rename(tmp_ids, target_ids);
+					break;
+				default:
+					err = -EBUSY;
+					break;
 				}
 			}
 		}
@@ -647,78 +406,28 @@ static int dnet_backend_set_ids(dnet_node *node, uint32_t backend_id, dnet_raw_i
 	return err;
 }
 
-void backend_fill_status_nolock(struct dnet_node *node, struct dnet_backend_status *status, const struct dnet_backend_info *config_backend)
-{
-	if (!status || !config_backend)
-		return;
+static int dnet_backend_create(struct dnet_node *node, uint32_t backend_id) {
+	try {
+		// check if backend with @backend_id is already initialized
+		if (node->io->backends_manager->get(backend_id))
+			return 0;
 
-	auto backend_id = config_backend->backend_id;
-	const dnet_backend_io *io = dnet_get_backend_io(node->io, backend_id);
+		auto config = dnet_node_get_config_data(node)->get_backend_config(backend_id);
+		if (!config)
+			return -ENOENT;
 
-	const auto &cb = config_backend->config.cb;
-
-	status->backend_id = backend_id;
-	status->state = config_backend->state;
-	if (config_backend->state == DNET_BACKEND_ENABLED && cb.defrag_status)
-		status->defrag_state = cb.defrag_status(cb.command_private);
-	status->last_start = config_backend->last_start;
-	status->last_start_err = config_backend->last_start_err;
-	status->read_only = io->read_only;
-	status->delay = io->delay;
-}
-
-void dnet_backend_info_manager::backend_fill_status(dnet_node *node, dnet_backend_status *status, size_t backend_id) const
-{
-	std::shared_ptr<dnet_backend_info> backend;
-	{
-		std::lock_guard<std::mutex> guard(backends_mutex);
-		auto it = backends.find(backend_id);
-		if (it != backends.end()) {
-			backend = it->second;
-		}
-	}
-	if (backend)
-	{
-		std::lock_guard<std::mutex> guard(*backend->state_mutex);
-		backend_fill_status_nolock(node, status, backend.get());
+		node->io->backends_manager->emplace(config);
+		return 0;
+	} catch (const std::exception &e) {
+		DNET_LOG_ERROR(node, "failed to add backend: {} : {}", backend_id, e.what());
+		return -ENOMEM;
 	}
 }
 
-std::shared_ptr<dnet_backend_info> dnet_backend_info_manager::get_backend(size_t backend_id) const
-{
-	std::lock_guard<std::mutex> guard(backends_mutex);
-	auto it = backends.find(backend_id);
-	if (it != backends.end()) {
-		return it->second;
-	}
-	return std::shared_ptr<dnet_backend_info>();
-}
-
-void dnet_backend_info_manager::add_backend(std::shared_ptr<dnet_backend_info> &backend)
-{
-	std::lock_guard<std::mutex> guard(backends_mutex);
-	backends.insert({backend->backend_id, backend});
-}
-
-void dnet_backend_info_manager::remove_backend(size_t backend_id) {
-	std::lock_guard<std::mutex> guard(backends_mutex);
-	backends.erase(backend_id);
-}
-
-void dnet_backend_info_manager::set_verbosity(dnet_log_level level) {
-	std::lock_guard<std::mutex> guard(backends_mutex);
-	for (auto &backend: backends) {
-		if (backend.second->state == DNET_BACKEND_ENABLED) {
-			backend.second->config.set_verbosity(&backend.second->config, level);
-		}
-	}
-}
-
-static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data)
-{
+static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data) {
 	int err = 0;
-	dnet_node *node = st->n;
-	struct dnet_backend_control *control = reinterpret_cast<dnet_backend_control *>(data);
+	struct dnet_node *node = st->n;
+	auto control = reinterpret_cast<struct dnet_backend_control *>(data);
 
 	if (dnet_backend_command(control->command) == DNET_BACKEND_ENABLE) {
 		err = dnet_backend_create(node, control->backend_id);
@@ -729,8 +438,7 @@ static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct 
 		}
 	}
 
-	auto backends = node->config_data->backends;
-	auto backend = backends->get_backend(control->backend_id);
+	auto backend = node->io->backends_manager->get(control->backend_id);
 	if (!backend) {
 		DNET_LOG_ERROR(node, "backend_control: there is no such backend: {}, state: {}", control->backend_id,
 		               dnet_state_dump_addr(st));
@@ -746,62 +454,45 @@ static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct 
 	DNET_LOG_INFO(node, "backend_control: received BACKEND_CONTROL: backend_id: {}, command: {}, state: {}",
 	              control->backend_id, control->command, dnet_state_dump_addr(st));
 
-	if (backend->state == DNET_BACKEND_UNITIALIZED) {
-		DNET_LOG_ERROR(node, "backend_control: there is no such backend: {}, state: {}", control->backend_id,
-		               dnet_state_dump_addr(st));
-		return -EINVAL;
-	}
-
-	dnet_backend_io *io = dnet_get_backend_io(node->io, control->backend_id);
-
-	const dnet_backend_callbacks &cb = backend->config.cb;
-
 	switch (dnet_backend_command(control->command)) {
 	case DNET_BACKEND_ENABLE:
-		err = dnet_backend_init(node, control->backend_id);
+		err = backend->enable();
 		break;
 	case DNET_BACKEND_DISABLE:
-		err = dnet_backend_cleanup(node, control->backend_id);
+		err = backend->disable();
 		break;
 	case DNET_BACKEND_REMOVE:
-		err = dnet_backend_remove(node, control->backend_id);
+		// disable backend before remove to avoid disabling it inside internal calls
+		backend->disable();
+		err = node->io->backends_manager->erase(control->backend_id);
 		break;
 	case DNET_BACKEND_START_DEFRAG:
-		if (cb.defrag_start) {
-			err = cb.defrag_start(cb.command_private,
-				static_cast<enum dnet_backend_defrag_level>(control->defrag_level));
-		} else {
-			err = -ENOTSUP;
-		}
+		err = backend->start_defrag((dnet_backend_defrag_level)control->defrag_level);
 		break;
 	case DNET_BACKEND_STOP_DEFRAG:
-		if (cb.defrag_stop) {
-			err = cb.defrag_stop(cb.command_private);
-		} else {
-			err = -ENOTSUP;
-		}
+		err = backend->stop_defrag();
 		break;
 	case DNET_BACKEND_SET_IDS:
-		err = dnet_backend_set_ids(st->n, control->backend_id, control->ids, control->ids_count);
+		err = backend->set_ids(control->ids, control->ids_count);
 		break;
 	case DNET_BACKEND_READ_ONLY:
-		if (io->read_only) {
+		if (backend->read_only()) {
 			err = -EALREADY;
 		} else {
-			io->read_only = 1;
+			backend->set_read_only();
 			err = 0;
 		}
 		break;
 	case DNET_BACKEND_WRITEABLE:
-		if (!io->read_only) {
+		if (!backend->read_only()) {
 			err = -EALREADY;
 		} else {
-			io->read_only = 0;
+			backend->set_read_only(false);
 			err = 0;
 		}
 		break;
 	case DNET_BACKEND_CTL:
-		io->delay = control->delay;
+		backend->set_delay(control->delay);
 		err = 0;
 		break;
 	default:
@@ -813,10 +504,9 @@ static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct 
 	memset(buffer, 0, sizeof(buffer));
 
 	dnet_backend_status_list *list = reinterpret_cast<dnet_backend_status_list *>(buffer);
-	dnet_backend_status *status = reinterpret_cast<dnet_backend_status *>(list + 1);
-
 	list->backends_count = 1;
-	backends->backend_fill_status(node, status, control->backend_id);
+
+	backend->fill_status(list->backends[0]);
 
 	if (err) {
 		dnet_send_reply(st, cmd, list, sizeof(buffer), true);
@@ -832,8 +522,7 @@ static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct 
 	return err;
 }
 
-int dnet_cmd_backend_control(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data)
-{
+int dnet_cmd_backend_control(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data) {
 	dnet_node *node = st->n;
 
 	if (cmd->size < sizeof(dnet_backend_control)) {
@@ -842,11 +531,7 @@ int dnet_cmd_backend_control(struct dnet_net_state *st, struct dnet_cmd *cmd, vo
 		return -EINVAL;
 	}
 
-	struct dnet_backend_control *control = reinterpret_cast<dnet_backend_control *>(data);
-
 	try {
-		ioremap::elliptics::backend_scope backend_scope{int(control->backend_id)};
-
 		return dnet_cmd_backend_control_dangerous(st, cmd, data);
 	} catch (std::bad_alloc &) {
 		DNET_LOG_ERROR(node, "backend_control: insufficient memory");
@@ -857,45 +542,193 @@ int dnet_cmd_backend_control(struct dnet_net_state *st, struct dnet_cmd *cmd, vo
 	}
 }
 
-int dnet_cmd_backend_status(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data)
-{
-	(void) data;
-	dnet_node *node = st->n;
+int dnet_cmd_backend_status(struct dnet_net_state *st, struct dnet_cmd *cmd) {
+	std::unique_ptr<dnet_backend_status_list, free_destroyer> list(st->n->io->backends_manager->get_status());
 
-	auto backends = node->config_data->backends->get_all_backends();
-	auto cmp_backends = [](const std::shared_ptr<dnet_backend_info> &lhs, const std::shared_ptr<dnet_backend_info> &rhs) -> bool {
-		return lhs->backend_id < rhs->backend_id;
-	};
-	std::sort(backends.begin(), backends.end(), cmp_backends);
-
-	const size_t total_size = sizeof(dnet_backend_status_list) + backends.size() * sizeof(dnet_backend_status);
-
-	std::unique_ptr<dnet_backend_status_list, free_destroyer>
-		list(reinterpret_cast<dnet_backend_status_list *>(calloc(1, total_size)));
-	if (!list) {
-		return -ENOMEM;
-	}
-
-	size_t i = 0;
-
-	for (auto &backend : backends) {
-		dnet_backend_status &status = list->backends[i];
-		node->config_data->backends->backend_fill_status(st->n, &status, backend->backend_id);
-		if (status.state != DNET_BACKEND_UNITIALIZED)
-			++i;
-	}
-
-	list->backends_count = i;
+	const size_t size = sizeof(dnet_backend_status_list) + list->backends_count * sizeof(dnet_backend_status);
 
 	cmd->flags &= ~DNET_FLAGS_NEED_ACK;
-
-	int err = dnet_send_reply(st, cmd, list.get(), total_size, false);
-
+	int err = dnet_send_reply(st, cmd, list.get(), size, false);
 	if (err != 0) {
 		cmd->flags |= DNET_FLAGS_NEED_ACK;
 	}
-
 	return err;
+}
+
+static dnet_logger &get_logger(struct dnet_node *node) {
+	return *(dnet_node_get_config_data(node)->logger->inner_logger());
+}
+
+dnet_backend::dnet_backend(dnet_node *node, std::shared_ptr<backend_config> config)
+: m_node{node}
+, m_config(config)
+, m_read_only{config->read_only_at_start}
+, m_delay{0}
+, m_state{DNET_BACKEND_DISABLED}
+, m_last_start_err{0}
+, m_cache{}
+, m_log{new blackhole::wrapper_t{get_logger(node), {{"source", "eblob"}, {"backend_id", m_config->backend_id}}}}
+, m_pool_id{} {
+	dnet_empty_time(&m_last_start);
+
+	memset(&m_callbacks, 0, sizeof(m_callbacks));
+}
+
+dnet_backend::~dnet_backend() {
+	disable();
+}
+
+uint32_t dnet_backend::backend_id() const {
+	return m_config->backend_id;
+}
+
+uint32_t dnet_backend::group_id() const {
+	return m_config->group_id;
+}
+
+uint64_t dnet_backend::queue_timeout() const {
+	return m_config->queue_timeout;
+}
+
+void dnet_backend::set_verbosity(const dnet_log_level level) {
+	boost::shared_lock<boost::shared_mutex> guard(m_state_mutex);
+	if (m_state != DNET_BACKEND_ENABLED)
+		return;
+
+	m_config->config_backend.set_verbosity(&m_config->config_backend, level);
+}
+
+int dnet_backend::enable() {
+	auto fail = [this](int err) {
+		detach_from_io_pool();
+		m_cache.reset();
+		{
+			dnet_current_time(&m_last_start);
+			m_last_start_err = err;
+			change_state(DNET_BACKEND_DISABLED);
+		}
+		return err;
+	};
+
+	dnet_time start;
+	dnet_current_time(&start);
+
+	int err = change_state(DNET_BACKEND_ACTIVATING);
+	if (err) {
+		DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, trying to activate not disabled backend, "
+		                       "elapsed: {}: {} [{}]",
+		               m_config->backend_id, elapsed(start), strerror(-err), err);
+		return err;
+	}
+
+	auto config = dnet_node_get_config_data(m_node)->get_backend_config(m_config->backend_id);
+	if (!config)
+		return -ENOENT;
+
+	m_config = std::move(config);
+
+	// reset delay after restart
+	m_delay = 0;
+	m_read_only = m_config->read_only_at_start;
+	m_config->config_backend.log = m_log.get();
+
+	m_command_stats.clear();
+
+	err = m_config->config_backend.init(&m_config->config_backend, dnet_node_get_verbosity(m_node));
+	if (err) {
+		DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, failed to init backend, "
+		                       "elapsed: {}: {} [{}]",
+		               m_config->backend_id, elapsed(start), strerror(-err), err);
+		return fail(err);
+	}
+
+	m_callbacks = m_config->config_backend.cb;
+
+	if (!m_config->pool_id.empty()) {
+		// use shared io pool if pool_id is set
+		m_pool = m_node->io->pools_manager->get(m_config->pool_id);
+	} else {
+		// use individual io pool if pool_id isn't set
+		m_pool = create_io_pool(m_node, std::to_string(m_config->backend_id), m_config->pool_config);
+	}
+
+	if (!m_pool) {
+		DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, failed to attach backend to io_pool, "
+		                       "elapsed: {}: {} [{}]",
+		               m_config->backend_id, elapsed(start), strerror(-err), err);
+		m_config->config_backend.cleanup(&m_config->config_backend);
+		return fail(err);
+	}
+
+	// use backend_id as pool_id for individual io pool
+	m_pool_id = m_config->pool_id.empty() ? std::to_string(m_config->backend_id) : m_config->pool_id;
+
+	if (m_config->cache_config) {
+		m_cache.reset(new ioremap::cache::cache_manager(m_node, *this, *m_config->cache_config));
+		if (!m_cache) {
+			err = -ENOMEM;
+			DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, failed to create cache, "
+			                       "elapsed: {}: {} [{}]",
+			               m_config->backend_id, elapsed(start), strerror(-err), err);
+			m_config->config_backend.cleanup(&m_config->config_backend);
+			return fail(err);
+		}
+	}
+
+	int ids_num = 0;
+	auto ids = dnet_ids_init(m_node, m_config->history, &ids_num, m_config->config_backend.storage_free,
+	                         m_node->addrs, m_config->backend_id);
+	if (ids == nullptr) {
+		err = -EINVAL;
+		DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, history path: {}, failed to initialize "
+		                       "ids, elapsed: {}: {} [{}]",
+		               m_config->backend_id, m_config->history, elapsed(start), strerror(-err), err);
+		m_config->config_backend.cleanup(&m_config->config_backend);
+		return fail(err);
+	}
+
+	err = dnet_route_list_enable_backend(m_node->route, m_config->backend_id, m_config->group_id, ids, ids_num);
+	free(ids);
+
+	if (err) {
+		DNET_LOG_ERROR(m_node, "dnet_backend::enable(): backend: {}, failed to add backend to route list, "
+		                       "elapsed: {}: {} [{}]",
+		               m_config->backend_id, elapsed(start), strerror(-err), err);
+		m_config->config_backend.cleanup(&m_config->config_backend);
+		return fail(err);
+	}
+
+	DNET_LOG_INFO(m_node, "dnet_backend::enable(): backend: {}, initialized, elapsed: {}", m_config->backend_id,
+	              elapsed(start));
+
+	change_state(DNET_BACKEND_ENABLED);
+	dnet_current_time(&m_last_start);
+	m_last_start_err = 0;
+
+	return 0;
+}
+
+int dnet_backend::disable() {
+	int err = change_state(DNET_BACKEND_DEACTIVATING);
+	if (err) {
+		DNET_LOG_ERROR(m_node, "dnet_backend::disable(): backend_id: {}, "
+		                       "trying to disable not enabled backend: {} [{}]",
+		               m_config->backend_id, strerror(-err), err);
+		return err;
+	}
+
+	dnet_route_list_disable_backend(m_node->route, m_config->backend_id);
+
+	detach_from_io_pool();
+
+	m_cache.reset();
+	m_config->config_backend.cleanup(&m_config->config_backend);
+	memset(&m_callbacks, 0, sizeof(m_callbacks));
+
+	m_command_stats.clear();
+
+	change_state(DNET_BACKEND_DISABLED);
+	return 0;
 }
 
 class bulk_read_handler : public std::enable_shared_from_this<bulk_read_handler> {
@@ -1041,71 +874,476 @@ int dnet_cmd_bulk_read_new(struct dnet_net_state *st, struct dnet_cmd *cmd, void
 	return 0;
 }
 
-void dnet_backend_info::parse(ioremap::elliptics::config::config_data *data,
-		const kora::config_t &backend)
-{
-	std::string type = backend.at<std::string>("type");
-
-	dnet_config_backend *backends_info[] = {
-		dnet_eblob_backend_info(),
+int dnet_backend::change_state(dnet_backend_state state) {
+	auto set_activating = [this]() {
+		switch (m_state) {
+		case DNET_BACKEND_DISABLED:
+			m_state = DNET_BACKEND_ACTIVATING; // only disabled backend can be enabled
+			return 0;
+		case DNET_BACKEND_ENABLED:
+			return -EALREADY; // backend is already enabled
+		case DNET_BACKEND_ACTIVATING:
+			return -EINPROGRESS; // backend's enabling is in progress
+		case DNET_BACKEND_DEACTIVATING:
+			return -EAGAIN; // backend's disabling is in progress
+		default:
+			return -EINVAL; // backend is in unknown state
+		}
 	};
 
-	bool found_backend = false;
-
-	for (size_t i = 0; i < sizeof(backends_info) / sizeof(backends_info[0]); ++i) {
-		dnet_config_backend *current_backend = backends_info[i];
-		if (type == current_backend->name) {
-			config_template = *current_backend;
-			config = *current_backend;
-			this->data.resize(config.size, '\0');
-			found_backend = true;
-			break;
+	auto set_deactivating = [this]() {
+		switch (m_state) {
+		case DNET_BACKEND_ENABLED:
+			m_state = DNET_BACKEND_DEACTIVATING; // only enabled backend can be disabled
+			return 0;
+		case DNET_BACKEND_DISABLED:
+			return -EALREADY; // backend is already disabled
+		case DNET_BACKEND_ACTIVATING:
+			return -EAGAIN; // backend's enabling is in progress
+		case DNET_BACKEND_DEACTIVATING:
+			return -EINPROGRESS; // backend's disabling is in progress
+		default:
+			return -EINVAL; // backend is in unknown state
 		}
-	}
+	};
 
-	if (!found_backend)
-		throw ioremap::elliptics::config::config_error() <<
-			backend["type"].path() <<
-			" is unknown backend";
+	boost::unique_lock<boost::shared_mutex> guard(m_state_mutex);
+	switch (state) {
+	case DNET_BACKEND_DISABLED:
+		m_state = DNET_BACKEND_DISABLED;
+		return 0;
+	case DNET_BACKEND_ENABLED:
+		m_state = DNET_BACKEND_ENABLED;
+		return 0;
+	case DNET_BACKEND_ACTIVATING:
+		return set_activating();
+	case DNET_BACKEND_DEACTIVATING:
+		return set_deactivating();
+	};
 
-	group = backend.at<uint32_t>("group");
-	history = backend.at<std::string>("history");
-	cache = NULL;
+	return -EINVAL;
+}
 
-	if (backend.has("cache")) {
-		const auto cache = backend["cache"];
-		cache_config = ioremap::cache::cache_config::parse(cache);
-	} else if (data->cache_config) {
-		cache_config = std::unique_ptr<ioremap::cache::cache_config>(new ioremap::cache::cache_config(*data->cache_config));
-	}
+void dnet_backend::detach_from_io_pool() {
+	// do nothing if backend isn't attached to any io pool
+	if (!m_pool)
+		return;
 
-	io_thread_num = backend.at("io_thread_num", data->cfg_state.io_thread_num);
-	nonblocking_io_thread_num = backend.at("nonblocking_io_thread_num", data->cfg_state.nonblocking_io_thread_num);
-
-	// use backend's queue_timeout if it's specified otherwise use global one.
-	if (backend.has("queue_timeout")) {
-		queue_timeout = ioremap::elliptics::config::parse_queue_timeout(backend);
+	if (!m_config->pool_id.empty()) {
+		// detach from shared io pool if pool_id was specified
+		m_pool.reset();
+		m_node->io->pools_manager->detach(m_pool_id);
 	} else {
-		queue_timeout = data->queue_timeout;
+		// stop individual io pool if no pool_id was specified
+		stop_io_pool(m_node, m_pool, m_pool_id);
+		m_pool.reset();
 	}
 
-	for (int i = 0; i < config.num; ++i) {
-		dnet_config_entry &entry = config.ent[i];
-		if (backend.has(entry.key)) {
-			const std::string value = [&] () {
-				std::ostringstream stream;
-				stream << backend[entry.key];
-				return stream.str();
-			} ();
+	m_pool_id.clear();
+}
 
-			dnet_backend_config_entry option = {
-				&entry,
-				std::move(value)
-			};
+int dnet_backend::start_defrag(const dnet_backend_defrag_level level) {
+	if (!m_callbacks.defrag_start) {
+		return -ENOTSUP;
+	}
 
-			options.emplace_back(std::move(option));
+	return m_callbacks.defrag_start(m_callbacks.command_private, level);
+}
+
+int dnet_backend::stop_defrag() {
+	if (!m_callbacks.defrag_stop)
+		return -ENOTSUP;
+
+	return m_callbacks.defrag_stop(m_callbacks.command_private);
+}
+
+int dnet_backend::set_ids(struct dnet_raw_id *ids, uint32_t ids_count) {
+	return dnet_backend_set_ids(m_node, *this, m_config, ids, ids_count);
+}
+
+void dnet_backend::fill_status(dnet_backend_status &status) {
+	boost::shared_lock<boost::shared_mutex> guard(m_state_mutex);
+
+	status.backend_id = m_config->backend_id;
+	status.state = m_state;
+	if (m_state == DNET_BACKEND_ENABLED && m_callbacks.defrag_status)
+		status.defrag_state = m_callbacks.defrag_status(m_callbacks.command_private);
+	status.last_start = m_last_start;
+	status.last_start_err = m_last_start_err;
+	status.read_only = m_read_only;
+	status.delay = m_delay;
+}
+
+void dnet_backend::fill_status(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	boost::shared_lock<boost::shared_mutex> guard(m_state_mutex);
+
+	value.AddMember("backend_id", m_config->backend_id, allocator);
+	rapidjson::Value status(rapidjson::kObjectType);
+	{
+		status.AddMember("backend_id",  m_config->backend_id, allocator);
+		status.AddMember("state",  (int)m_state, allocator);
+		status.AddMember("string_state",  dnet_backend_state_string(m_state), allocator);
+		status.AddMember("read_only",  m_read_only, allocator);
+		status.AddMember("delay",  m_delay, allocator);
+		status.AddMember("group",  m_config->group_id, allocator);
+		status.AddMember("pool_id", m_pool_id.c_str(), allocator);
+		const auto defrag_state = (m_state == DNET_BACKEND_ENABLED && m_callbacks.defrag_status)
+		                                  ? m_callbacks.defrag_status(m_callbacks.command_private)
+		                                  : 0;
+		status.AddMember("defrag_state", defrag_state, allocator);
+		status.AddMember("string_defrag_state", dnet_backend_defrag_state_string(defrag_state), allocator);
+		rapidjson::Value last_start(rapidjson::kObjectType);
+		{
+			last_start.AddMember("tv_sec", m_last_start.tsec, allocator);
+			last_start.AddMember("tv_usec", m_last_start.tnsec / 1000, allocator);
+		}
+		status.AddMember("last_start", last_start, allocator);
+		status.AddMember("string_last_time", dnet_print_time(&m_last_start), allocator);
+		status.AddMember("last_start_err", m_last_start_err, allocator);
+	}
+	value.AddMember("status", status, allocator);
+}
+
+void dnet_backend::fill_backend_stats(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	rapidjson::Document backend(&allocator);
+	if (m_state == DNET_BACKEND_ENABLED) {
+		char *json_stat = nullptr;
+		size_t json_size = 0;
+		m_callbacks.storage_stat_json(m_callbacks.command_private, &json_stat, &json_size);
+		if (json_stat && json_size) {
+			backend.Parse<0>(json_stat);
+			auto &config_value = backend["config"];
+			config_value.AddMember("group", m_config->group_id, allocator);
+			config_value.AddMember("queue_timeout", m_config->queue_timeout, allocator);
+		}
+		free(json_stat);
+	} else {
+		if (m_state == DNET_BACKEND_DISABLED) {
+			/* load actual config from config file. Load only for disabled backend since
+			 * in other state current config is in-use.
+			 */
+			auto config = dnet_node_get_config_data(m_node)->get_backend_config(m_config->backend_id);
+			if (config)
+				m_config = std::move(config);
+		}
+
+		char *json_stat = nullptr;
+		size_t json_size = 0;
+		m_config->config_backend.to_json(&m_config->config_backend, &json_stat, &json_size);
+		if (json_stat && json_size) {
+			rapidjson::Document config_value(&allocator);
+			config_value.Parse<0>(json_stat);
+			config_value.AddMember("group", m_config->group_id, allocator);
+			config_value.AddMember("queue_timeout", m_config->queue_timeout, allocator);
+			backend.SetObject();
+			backend.AddMember("config", static_cast<rapidjson::Value &>(config_value), allocator);
+		}
+		free(json_stat);
+	}
+
+	if (!backend.IsObject())
+		backend.SetObject();
+
+	rapidjson::Document initial_config(&allocator);
+	initial_config.Parse<0>(m_config->raw_config.c_str());
+	backend.AddMember("initial_config", static_cast<rapidjson::Value &>(initial_config), allocator);
+
+	value.AddMember("backend", static_cast<rapidjson::Value &>(backend), allocator);
+}
+
+void dnet_backend::fill_io_stats(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	if (m_state != DNET_BACKEND_ENABLED)
+		return;
+
+	rapidjson::Value io(rapidjson::kObjectType);
+	ioremap::monitor::dump_io_pool_stats(*m_pool, io, allocator);
+	value.AddMember("io", io, allocator);
+}
+
+void dnet_backend::fill_cache_stats(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	if (m_state != DNET_BACKEND_ENABLED || !m_cache)
+		return;
+
+	rapidjson::Value cache;
+	m_cache->statistics(cache, allocator);
+	value.AddMember("cache", cache, allocator);
+}
+
+void dnet_backend::fill_commands_stats(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator) {
+	if (m_state != DNET_BACKEND_ENABLED)
+		return;
+
+	rapidjson::Value commands_value(rapidjson::kObjectType);
+	m_command_stats.commands_report(nullptr, commands_value, allocator);
+	value.AddMember("commands", commands_value, allocator);
+}
+
+void dnet_backend::statistics(uint64_t categories,
+                              rapidjson::Value &value,
+                              rapidjson::Document::AllocatorType &allocator) {
+	boost::shared_lock<boost::shared_mutex> guard(m_state_mutex);
+	fill_status(value, allocator);
+	if (categories & DNET_MONITOR_BACKEND)
+		fill_backend_stats(value, allocator);
+	if (categories & DNET_MONITOR_IO)
+		fill_io_stats(value, allocator);
+	if (categories & DNET_MONITOR_CACHE)
+		fill_cache_stats(value, allocator);
+	if (categories & DNET_MONITOR_COMMANDS)
+		fill_commands_stats(value, allocator);
+}
+
+dnet_backends_manager::dnet_backends_manager(struct dnet_node *node)
+: m_node(node) {
+	auto data = dnet_node_get_config_data(node);
+	m_backends.reserve(data->backends.size());
+
+	for (auto &config : data->backends) {
+		emplace(std::move(config));
+	}
+
+	// data->backends has been used and now longer needed, so clear it.
+	data->backends.clear();
+}
+
+dnet_backends_manager::~dnet_backends_manager() {
+	clear();
+}
+
+bool dnet_backends_manager::emplace(std::shared_ptr<backend_config> config) {
+	if (m_backends.find(config->backend_id) != m_backends.end())
+		return false;
+
+	m_backends.emplace(config->backend_id, std::make_shared<dnet_backend>(m_node, config));
+	return true;
+}
+
+std::shared_ptr<dnet_backend> dnet_backends_manager::get(uint32_t backend_id) {
+	boost::shared_lock<boost::shared_mutex> guard(m_backends_mutex);
+
+	auto it = m_backends.find(backend_id);
+	if (it == m_backends.end())
+		return nullptr;
+
+	return it->second;
+}
+
+int dnet_backends_manager::erase(uint32_t backend_id) {
+	boost::unique_lock<boost::shared_mutex> guard(m_backends_mutex);
+	return m_backends.erase(backend_id) == 0 ? -ENOENT : 0;
+}
+
+void dnet_backends_manager::clear() {
+	boost::upgrade_lock<boost::shared_mutex> guard(m_backends_mutex);
+	for (auto &item: m_backends) {
+		auto &backend = item.second;
+		backend->disable();
+	}
+
+	boost::upgrade_to_unique_lock<boost::shared_mutex> unique_guard(guard);
+	m_backends.clear();
+}
+
+int dnet_backends_manager::init_all(bool parallel) {
+	int err = 1;
+
+	if (parallel) {
+		try {
+			using namespace ioremap::elliptics;
+			session sess(m_node);
+			sess.set_filter(filters::all_with_ack);
+			sess.set_checker(checkers::no_check);
+			sess.set_exceptions_policy(session::no_exceptions);
+			sess.set_timeout(std::numeric_limits<unsigned>::max() / 2);
+			sess.set_cflags(sess.get_cflags() | DNET_FLAGS_NO_QUEUE_TIMEOUT);
+
+			std::vector<async_backend_control_result> results;
+			results.reserve(m_backends.size());
+
+			for (const auto &item : m_backends) {
+				const auto &backend_id = item.first;
+				const auto &backend = item.second;
+
+				if (!backend->config()->enable_at_start)
+					continue;
+
+				results.emplace_back(sess.enable_backend(m_node->st->addr, backend_id));
+			}
+
+			if (results.size()) {
+				async_backend_control_result result =
+				        ioremap::elliptics::aggregated(sess, results.begin(), results.end());
+				result.wait();
+
+				err = result.error().code();
+				if (err)
+					DNET_LOG_ERROR(m_node, "Failed to initialize backends: {}", err);
+			}
+		} catch (std::bad_alloc &) {
+			return -ENOMEM;
+		}
+	} else {
+		for (const auto &item : m_backends) {
+			auto &backend = item.second;
+
+			if (!backend->config()->enable_at_start)
+				continue;
+
+			const int tmp = backend->enable();
+			// set @err to @tmp if it wasn't set yet or if backend was successfully enabled
+			if ((err == 1) || !tmp) {
+				err = tmp;
+			}
 		}
 	}
 
-	initial_config = kora::to_json(backend.underlying_object());
+	// if @err is still 1 then no backends should be enabled at start
+	if (err == 1)
+		err = 0;
+
+	DNET_LOG(m_node, err ? DNET_LOG_ERROR : DNET_LOG_NOTICE,
+	         "dnet_backends_manager::init_all(): finished initializing all backends: {}", err);
+
+	return err;
+}
+
+
+void dnet_backends_manager::set_verbosity(const dnet_log_level level) {
+	boost::shared_lock<boost::shared_mutex> guard(m_backends_mutex);
+
+	for (const auto &item: m_backends) {
+		const auto &backend = item.second;
+		backend->set_verbosity(level);
+	}
+}
+
+struct dnet_backend_status_list *dnet_backends_manager::get_status() {
+	boost::shared_lock<boost::shared_mutex> guard(m_backends_mutex);
+	auto backends = [this]() {
+		std::vector<std::shared_ptr<dnet_backend>> sorted;
+		sorted.reserve(m_backends.size());
+		for (auto &item : m_backends) {
+			const auto &backend = item.second;
+			sorted.emplace_back(backend);
+		}
+
+		std::sort(sorted.begin(), sorted.end(), [](const std::shared_ptr<dnet_backend> &lhs,
+		                                           const std::shared_ptr<dnet_backend> &rhs) {
+			return lhs->backend_id() < rhs->backend_id();
+		});
+		return std::move(sorted);
+	}();
+
+	const size_t size = sizeof(dnet_backend_status_list) + backends.size() * sizeof(dnet_backend_status);
+
+	auto list = reinterpret_cast<dnet_backend_status_list *>(calloc(1, size));
+
+	for (size_t i = 0; i < backends.size(); ++i) {
+		backends[i]->fill_status(list->backends[i]);
+	}
+	list->backends_count = backends.size();
+
+	return list;
+}
+
+void dnet_backends_manager::statistics(uint64_t categories,
+                                       rapidjson::Value &value,
+                                       rapidjson::Document::AllocatorType &allocator) {
+	value.SetObject();
+
+	boost::shared_lock<boost::shared_mutex> guard(m_backends_mutex);
+	for (auto &item: m_backends) {
+		const auto &backend_id = std::to_string(item.first);
+		auto &backend = item.second;
+
+		rapidjson::Value backend_value(rapidjson::kObjectType);
+		backend->statistics(categories, backend_value, allocator);
+		value.AddMember(backend_id.c_str(), allocator, backend_value, allocator);
+	}
+}
+
+void dnet_io_pools_fill_stats(struct dnet_node *node,
+                              rapidjson::Value &value,
+                              rapidjson::Document::AllocatorType &allocator) {
+	node->io->pools_manager->statistics(value, allocator);
+}
+
+void dnet_io_pools_check(struct dnet_io_pools_manager *pools_manager, uint64_t *queue_size, uint64_t *threads_count) {
+	if (!pools_manager)
+		return;
+
+	// TODO(shaitan): it should count also individual io pools.
+	pools_manager->check(*queue_size, *threads_count);
+}
+
+int dnet_backends_init(struct dnet_node *node) {
+	std::unique_ptr<dnet_io_pools_manager> pools{new(std::nothrow) dnet_io_pools_manager(node)};
+	if (!pools) {
+		DNET_LOG_ERROR(node, "backends: failed to initialize dnet_io_pools_manager");
+		return -ENOMEM;
+	}
+
+	std::unique_ptr<dnet_backends_manager> backends{new(std::nothrow) dnet_backends_manager(node)};
+	if (!backends) {
+		DNET_LOG_ERROR(node, "backends: failed to initialize dnet_backends_manager");
+		return -ENOMEM;
+	}
+
+	node->io->pools_manager = pools.release();
+	node->io->backends_manager = backends.release();
+
+	return 0;
+}
+
+void dnet_backends_destroy(struct dnet_node *node) {
+	delete node->io->backends_manager;
+	delete node->io->pools_manager;
+}
+
+struct dnet_backend *dnet_backends_get_backend_locked(struct dnet_node *node, uint32_t backend_id) {
+	auto backend = node->io->backends_manager->get(backend_id);
+	if (!backend)
+		return nullptr;
+
+	boost::shared_lock<boost::shared_mutex> guard(backend->state_mutex());
+	if (backend->state() != DNET_BACKEND_ENABLED)
+		return nullptr;
+
+	// leave shared lock on backend's state_mutex to prevent changing backend's state while backend is in use
+	guard.release();
+
+	return backend.get();
+}
+
+struct dnet_io_pool *dnet_backend_get_pool(struct dnet_node *node, uint32_t backend_id) {
+	if (!node || !node->io || !node->io->backends_manager)
+		return nullptr;
+
+	auto backend = node->io->backends_manager->get(backend_id);
+	if (!backend)
+		return nullptr;
+
+	return backend->io_pool();
+}
+
+uint64_t dnet_backend_get_queue_timeout(struct dnet_node *node, ssize_t backend_id) {
+	if (!node || !node->io || !node->io->backends_manager)
+		return 0;
+	if (backend_id < 0)
+		return dnet_node_get_queue_timeout(node);
+
+	auto backend = node->io->backends_manager->get(backend_id);
+	if (!backend)
+		return dnet_node_get_queue_timeout(node);
+
+	return backend->queue_timeout();
+}
+
+int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
+                                 struct dnet_net_state *st,
+                                 struct dnet_cmd *cmd,
+                                 void *data,
+                                 struct dnet_cmd_stats *cmd_stats) {
+	auto &callbacks = backend->callbacks();
+	return callbacks.command_handler(st, callbacks.command_private, cmd, data, cmd_stats);
 }

--- a/library/compat.c
+++ b/library/compat.c
@@ -23,6 +23,7 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 
+#include <stdarg.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -170,47 +171,5 @@ int dnet_sendfile(struct dnet_net_state *st, int fd, uint64_t *offset, uint64_t 
 
 	return -EAGAIN;
 }
-#endif
-
-#ifdef HAVE_IOPRIO_SUPPORT
-
-enum {
-	IOPRIO_CLASS_NONE,
-	IOPRIO_CLASS_RT,
-	IOPRIO_CLASS_BE,
-	IOPRIO_CLASS_IDLE,
-};
-
-enum {
-	IOPRIO_WHO_PROCESS = 1,
-	IOPRIO_WHO_PGRP,
-	IOPRIO_WHO_USER,
-};
-
-/*
- * Gives us 8 prio classes with 13-bits of data for each class
- */
-#define IOPRIO_BITS             (16)
-#define IOPRIO_CLASS_SHIFT      (13)
-#define IOPRIO_PRIO_MASK        ((1UL << IOPRIO_CLASS_SHIFT) - 1)
-
-#define IOPRIO_PRIO_CLASS(mask) ((mask) >> IOPRIO_CLASS_SHIFT)
-#define IOPRIO_PRIO_DATA(mask)  ((mask) & IOPRIO_PRIO_MASK)
-#define IOPRIO_PRIO_VALUE(class, data)  (((class) << IOPRIO_CLASS_SHIFT) | data)
-
-#define ioprio_valid(mask)      (IOPRIO_PRIO_CLASS((mask)) != IOPRIO_CLASS_NONE)
-
-int dnet_ioprio_set(long pid, int class, int prio)
-{
-	return syscall(SYS_ioprio_set, IOPRIO_WHO_PROCESS, pid, IOPRIO_PRIO_VALUE(class, prio));
-}
-
-int dnet_ioprio_get(long pid)
-{
-	return syscall(SYS_ioprio_get, IOPRIO_WHO_PROCESS, pid);
-}
-#else
-int dnet_ioprio_set(long pid __attribute__ ((unused)), int class __attribute__ ((unused)), int prio __attribute__ ((unused))) { return 0; }
-int dnet_ioprio_get(long pid __attribute__ ((unused))) { return 0; }
 #endif
 

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -36,7 +36,9 @@
 #include <unistd.h>
 
 #include "elliptics.h"
+#include "backend.h"
 #include "request_queue.h"
+#include "route.h"
 #include "monitor/monitor.h"
 
 #include "elliptics/packet.h"
@@ -46,59 +48,7 @@
 
 #include "logger.hpp"
 
-int dnet_remove_local_new(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_id *id,
-			  void *packet, size_t packet_size)
-{
-	int err;
-	struct dnet_cmd cmd;
-	struct dnet_cmd_stats cmd_stats;
-
-	memset(&cmd, 0, sizeof(struct dnet_cmd));
-	memset(&cmd_stats, 0, sizeof(struct dnet_cmd_stats));
-
-	cmd.id = *id;
-	cmd.size = packet_size;
-	cmd.flags = DNET_FLAGS_NOLOCK;
-	cmd.cmd = DNET_CMD_DEL_NEW;
-
-	err = backend->cb->command_handler(n->st, backend->cb->command_private, &cmd, packet, &cmd_stats);
-	dnet_log(n, DNET_LOG_NOTICE, "%s: local remove_new: err: %d", dnet_dump_id(&cmd.id), err);
-
-	return err;
-}
-
-int dnet_remove_local(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_id *id)
-{
-	const size_t cmd_size = sizeof(struct dnet_cmd) + sizeof(struct dnet_io_attr);
-	int err;
-	char buffer[cmd_size];
-	struct dnet_cmd *cmd = (struct dnet_cmd *)buffer;
-	struct dnet_io_attr *io = (struct dnet_io_attr *)(cmd + 1);
-	struct dnet_cmd_stats cmd_stats;
-
-	memset(buffer, 0, cmd_size);
-	memset(&cmd_stats, 0, sizeof(cmd_stats));
-
-	cmd->id = *id;
-	cmd->size = cmd_size - sizeof(struct dnet_cmd);
-	cmd->flags = DNET_FLAGS_NOLOCK;
-	cmd->cmd = DNET_CMD_DEL;
-
-	io->flags = DNET_IO_FLAGS_SKIP_SENDING;
-
-	memcpy(io->parent, id->id, DNET_ID_SIZE);
-	memcpy(io->id, id->id, DNET_ID_SIZE);
-
-	dnet_convert_io_attr(io);
-
-	err = backend->cb->command_handler(n->st, backend->cb->command_private, cmd, io, &cmd_stats);
-	dnet_log(n, DNET_LOG_NOTICE, "%s: local remove: err: %d", dnet_dump_id(&cmd->id), err);
-
-	return err;
-}
-
-static int dnet_cmd_route_list(struct dnet_net_state *orig, struct dnet_cmd *cmd)
-{
+static int dnet_cmd_route_list(struct dnet_net_state *orig, struct dnet_cmd *cmd) {
 	struct dnet_node *n = orig->n;
 	struct dnet_net_state *st;
 	struct dnet_addr_cmd *acmd = NULL;
@@ -1109,18 +1059,20 @@ static int dnet_iterator_check_ts_range(struct dnet_net_state *st, struct dnet_c
 	return 0;
 }
 
-static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd,
-		struct dnet_iterator_request *ireq)
-{
+static int dnet_iterator_start(struct dnet_backend *backend,
+                               struct dnet_net_state *st,
+                               struct dnet_cmd *cmd,
+                               struct dnet_iterator_request *ireq) {
 	struct dnet_iterator_range *irange = (struct dnet_iterator_range *)(ireq + 1);
 	int *dst_groups = (int *)(irange + ireq->range_num);
+	struct dnet_backend_callbacks *callbacks = dnet_backend_get_callbacks(backend);
 
 	struct dnet_iterator_common_private cpriv = {
 		.req = ireq,
 		.range = irange,
 	};
 	struct dnet_iterator_ctl ictl = {
-		.iterate_private = backend->cb->command_private,
+		.iterate_private = callbacks->command_private,
 		.callback = dnet_iterator_callback_common,
 		.callback_private = &cpriv,
 	};
@@ -1130,7 +1082,7 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 	int err = 0;
 
 	/* Check that backend supports iterator */
-	if (!backend->cb->iterator) {
+	if (!callbacks->iterator) {
 		err = -ENOTSUP;
 		dnet_log(st->n, DNET_LOG_ERROR, "%s: iteration failed: backend doesn't support iteration",
 		         dnet_dump_id(&cmd->id));
@@ -1160,8 +1112,8 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 
 	atomic_init(&cpriv.iterated_keys, 0);
 
-	if (backend->cb->total_elements)
-		cpriv.total_keys = backend->cb->total_elements(backend->cb->command_private);
+	if (callbacks->total_elements)
+		cpriv.total_keys = callbacks->total_elements(callbacks->command_private);
 	else
 		cpriv.total_keys = 0;
 
@@ -1217,7 +1169,7 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 
 		sspriv->timeout = ireq->timeout;
 		sspriv->iflags = ireq->flags;
-		sspriv->backend_id = backend->backend_id;
+		sspriv->backend_id = dnet_backend_get_backend_id(backend);
 
 		cpriv.next_callback = dnet_iterator_callback_server_send;
 		cpriv.next_private = sspriv;
@@ -1237,7 +1189,7 @@ static int dnet_iterator_start(struct dnet_backend_io *backend, struct dnet_net_
 	}
 
 	/* Run iterator */
-	err = backend->cb->iterator(&ictl, ireq, irange);
+	err = callbacks->iterator(&ictl, ireq, irange);
 
 	/* Remove iterator */
 	dnet_iterator_destroy(st->n, cpriv.it);
@@ -1262,8 +1214,10 @@ err_out_exit:
 /*!
  * Starts low-level backend iterator and passes data to network or file
  */
-static int dnet_cmd_iterator(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_cmd *cmd, void *data)
-{
+static int dnet_cmd_iterator(struct dnet_backend *backend,
+                             struct dnet_net_state *st,
+                             struct dnet_cmd *cmd,
+                             void *data) {
 	struct dnet_iterator_request *ireq = data;
 	int err = 0;
 
@@ -1315,7 +1269,7 @@ err_out_exit:
 	return err;
 }
 
-static int dnet_cmd_bulk_read(struct dnet_backend_io *backend,
+static int dnet_cmd_bulk_read(struct dnet_backend *backend,
                               struct dnet_net_state *st,
                               struct dnet_cmd *cmd,
                               void *data,
@@ -1327,12 +1281,16 @@ static int dnet_cmd_bulk_read(struct dnet_backend_io *backend,
 	uint64_t count = 0;
 	uint64_t i;
 	int use_oplock;
+	struct dnet_io_pool *pool = NULL;
 	struct dnet_id lock_id = { .group_id = cmd->id.group_id };
 
 	struct dnet_cmd read_cmd = *cmd;
 	read_cmd.size = sizeof(struct dnet_io_attr);
 	read_cmd.cmd = DNET_CMD_READ;
 	read_cmd.flags |= DNET_FLAGS_MORE;
+	read_cmd.backend_id = dnet_backend_get_backend_id(backend);
+
+	pool = dnet_backend_get_pool(st->n, read_cmd.backend_id);
 
 	dnet_convert_io_attr(io);
 	count = io->size / sizeof(struct dnet_io_attr);
@@ -1349,15 +1307,15 @@ static int dnet_cmd_bulk_read(struct dnet_backend_io *backend,
 					!dnet_id_cmp_str((const unsigned char *)&ios[i].id, (const unsigned char *)&cmd->id.id);
 		if (use_oplock) {
 			memcpy(&lock_id.id, &ios[i].id, DNET_ID_SIZE);
-			dnet_oplock(backend, &lock_id);
+			dnet_oplock(pool, &lock_id);
 		}
 
-		ret = dnet_process_cmd_raw(backend, st, &read_cmd, &ios[i], 1, cmd_stats->queue_time);
+		ret = dnet_process_cmd_raw(st, &read_cmd, &ios[i], 1, cmd_stats->queue_time);
 		dnet_log(st->n, DNET_LOG_NOTICE, "%s: processing BULK_READ.READ for %d/%d command, err: %d",
 			dnet_dump_id(&cmd->id), (int) i, (int) count, ret);
 
 		if (use_oplock) {
-			dnet_opunlock(backend, &lock_id);
+			dnet_opunlock(pool, &lock_id);
 		}
 
 		if (!ret)
@@ -1369,18 +1327,22 @@ static int dnet_cmd_bulk_read(struct dnet_backend_io *backend,
 	return err;
 }
 
-static int dnet_cas_local(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_id *id, void *remote_csum, int csize)
-{
+static int dnet_cas_local(struct dnet_backend *backend,
+                          struct dnet_node *n,
+                          struct dnet_id *id,
+                          void *remote_csum,
+                          int csize) {
 	char csum[DNET_ID_SIZE];
 	int err = 0;
+	struct dnet_backend_callbacks *callbacks = dnet_backend_get_callbacks(backend);
 
-	if (!backend->cb->checksum) {
+	if (!callbacks->checksum) {
 		dnet_log(n, DNET_LOG_ERROR, "%s: cas: checksum operation is not supported in backend",
 				dnet_dump_id(id));
 		return -ENOTSUP;
 	}
 
-	err = backend->cb->checksum(n, backend->cb->command_private, id, csum, &csize);
+	err = callbacks->checksum(n, callbacks->command_private, id, csum, &csize);
 	if (err != 0 && err != -ENOENT) {
 		dnet_log(n, DNET_LOG_ERROR, "%s: cas: checksum operation failed", dnet_dump_id(id));
 		return err;
@@ -1419,12 +1381,12 @@ static int dnet_cas_local(struct dnet_backend_io *backend, struct dnet_node *n, 
  * Check timestamp of the existing record if compare-and-swap timestamp flag is set.
  * If on-disk record's timestamp is higher than that in IO structure, do not allow this write.
  */
-static int dnet_cas_timestamp_local(struct dnet_backend_io *backend, struct dnet_node *n, struct dnet_io_attr *req)
-{
+static int dnet_cas_timestamp_local(struct dnet_backend *backend, struct dnet_node *n, struct dnet_io_attr *req) {
 	struct dnet_io_local io;
 	int err;
+	struct dnet_backend_callbacks *callbacks = dnet_backend_get_callbacks(backend);
 
-	if (!backend->cb->lookup) {
+	if (!callbacks->lookup) {
 		dnet_log(n, DNET_LOG_ERROR, "%s: cas: lookup operation is not supported in backend",
 				dnet_dump_id_str(req->id));
 		err = -ENOTSUP;
@@ -1436,7 +1398,7 @@ static int dnet_cas_timestamp_local(struct dnet_backend_io *backend, struct dnet
 
 	io.fd = -1;
 
-	err = backend->cb->lookup(n, backend->cb->command_private, &io);
+	err = callbacks->lookup(n, callbacks->command_private, &io);
 	if (err) {
 		/*
 		 * There is no given key, allow this write
@@ -1466,232 +1428,210 @@ err_out_exit:
 	return err;
 }
 
-// Keep this enums in sync with enums from dnet_cmd_needs_backend
-static int dnet_process_cmd_without_backend_raw(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data)
-{
-	int err = 0;
+static int dnet_cmd_notify(struct dnet_net_state *st, struct dnet_cmd *cmd) {
+	if (cmd->flags & DNET_ATTR_DROP_NOTIFICATION)
+		return dnet_notify_remove(st, cmd);
 
-	switch (cmd->cmd) {
-		case DNET_CMD_AUTH:
-			err = dnet_cmd_auth(st, cmd, data);
-			break;
-		case DNET_CMD_STATUS:
-			err = dnet_cmd_status(st, cmd, data);
-			break;
-		case DNET_CMD_REVERSE_LOOKUP:
-			err = dnet_route_list_reverse_lookup(st, cmd, data);
-			break;
-		case DNET_CMD_JOIN:
-			err = dnet_route_list_join(st, cmd, data);
-			break;
-		case DNET_CMD_ROUTE_LIST:
-			err = dnet_cmd_route_list(st, cmd);
-			break;
-		case DNET_CMD_MONITOR_STAT:
-			err = dnet_monitor_process_cmd(st, cmd, data);
-			break;
-		case DNET_CMD_BACKEND_CONTROL:
-			err = dnet_cmd_backend_control(st, cmd, data);
-			break;
-		case DNET_CMD_BACKEND_STATUS:
-			err = dnet_cmd_backend_status(st, cmd, data);
-			break;
-		case DNET_CMD_BULK_READ_NEW:
-			err = dnet_cmd_bulk_read_new(st, cmd, data);
-			break;
-		default:
-			err = -ENOTSUP;
-			break;
-	}
-
+	const int err = dnet_notify_add(st, cmd);
+	/*
+	 * We drop 'need ack' flag, since notification
+	 * transaction is a long-living one, since
+	 * every notification will be sent as transaction
+	 * completion.
+	 *
+	 * Transaction acknowledge will be sent when
+	 * notification is removed.
+	 */
+	if (!err)
+		cmd->flags &= ~DNET_FLAGS_NEED_ACK;
 	return err;
 }
 
-static int dnet_process_cmd_with_backend_raw(struct dnet_backend_io *backend, struct dnet_net_state *st,
-		struct dnet_cmd *cmd, void *data, struct dnet_cmd_stats *cmd_stats)
-{
+// Keep this enums in sync with enums from dnet_cmd_needs_backend
+static int dnet_process_cmd_without_backend_raw(struct dnet_net_state *st,
+                                                struct dnet_cmd *cmd,
+                                                void *data,
+                                                struct dnet_cmd_stats *cmd_stats) {
+	switch (cmd->cmd) {
+	case DNET_CMD_AUTH:
+		return dnet_cmd_auth(st, cmd, data);
+	case DNET_CMD_STATUS:
+		return dnet_cmd_status(st, cmd, data);
+	case DNET_CMD_REVERSE_LOOKUP:
+		return dnet_route_list_reverse_lookup(st, cmd, data);
+	case DNET_CMD_JOIN:
+		return dnet_route_list_join(st, cmd, data);
+	case DNET_CMD_ROUTE_LIST:
+		return dnet_cmd_route_list(st, cmd);
+	case DNET_CMD_MONITOR_STAT:
+		return dnet_monitor_process_cmd(st, cmd, data);
+	case DNET_CMD_BACKEND_CONTROL:
+		return dnet_cmd_backend_control(st, cmd, data);
+	case DNET_CMD_BACKEND_STATUS:
+		return dnet_cmd_backend_status(st, cmd);
+	case DNET_CMD_NOTIFY:
+		return dnet_cmd_notify(st, cmd);
+	case DNET_CMD_BULK_READ_NEW:
+		return dnet_cmd_bulk_read_new(st, cmd, data);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dnet_cmd_send(struct dnet_backend *backend,
+                         struct dnet_net_state *st,
+                         struct dnet_cmd *cmd,
+                         void *data,
+                         struct dnet_cmd_stats *cmd_stats) {
+	struct dnet_server_send_request *req = data;
+	dnet_convert_server_send_request(req);
+
+	if (req->id_num == 0) {
+		dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid send command: id_num must be non zero",
+		         dnet_dump_id(&cmd->id));
+		return -EINVAL;
+	}
+
+	if (req->group_num == 0) {
+		dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid send command: group_num must be non zero",
+		         dnet_dump_id(&cmd->id));
+		return -EINVAL;
+	}
+
+	size_t req_size = sizeof(struct dnet_server_send_request) +
+				req->id_num * sizeof(struct dnet_raw_id) +
+				req->group_num * sizeof(int);
+
+	if (cmd->size != req_size) {
+		dnet_log(st->n, DNET_LOG_ERROR,
+		         "%s: invalid send command: size mismatch: cmd size: %llu, request size: %zd",
+		         dnet_dump_id(&cmd->id), (unsigned long long)cmd->size, req_size);
+		return -EINVAL;
+	}
+
+	dnet_convert_server_send_request(req);
+	return dnet_backend_process_cmd_raw(backend, st, cmd, data, cmd_stats);
+}
+
+static int dnet_process_cmd_with_backend_raw(struct dnet_net_state *st,
+                                             struct dnet_cmd *cmd,
+                                             void *data,
+                                             struct dnet_cmd_stats *cmd_stats) {
 	int err = 0;
 	struct dnet_node *n = st->n;
 	struct dnet_io_attr *io = NULL;
 	struct timeval start, end;
-	struct dnet_server_send_request *req;
+	struct dnet_backend *backend = NULL;
 
 	gettimeofday(&start, NULL);
 
+	backend = dnet_backends_get_backend_locked(n, cmd->backend_id);
+	if (!backend)
+		return -ENOTSUP;
+
 	// sleep before running a command, since for some commands ->command_handler sends reply itself,
 	// and client will not wait for this thread to finish
-	if (backend->delay) {
-		long seconds = backend->delay / 1000;
-		long useconds = (backend->delay % 1000) * 1000;
-
-		if (seconds) {
-			sleep(seconds);
-		}
-
-		if (useconds) {
-			usleep(useconds);
-		}
-	}
+	dnet_backend_sleep_delay(backend);
 
 	// TODO(shaitan): pass @cmd_stats to all handling functions to update statistics
 	switch (cmd->cmd) {
-		case DNET_CMD_ITERATOR:
-			err = dnet_cmd_iterator(backend, st, cmd, data);
+	case DNET_CMD_ITERATOR:
+		err = dnet_cmd_iterator(backend, st, cmd, data);
+		break;
+	case DNET_CMD_SEND:
+		err = dnet_cmd_send(backend, st, cmd, data, cmd_stats);
+		break;
+	case DNET_CMD_BULK_READ:
+		err = dnet_backend_process_cmd_raw(backend, st, cmd, data, cmd_stats);
+		if (err == -ENOTSUP)
+			err = dnet_cmd_bulk_read(backend, st, cmd, data, cmd_stats);
+		break;
+	case DNET_CMD_READ:
+	case DNET_CMD_WRITE:
+	case DNET_CMD_DEL:
+		if ((n->ro || dnet_backend_read_only(backend)) &&
+		    ((cmd->cmd == DNET_CMD_DEL) || (cmd->cmd == DNET_CMD_WRITE))) {
+			err = -EROFS;
 			break;
-		case DNET_CMD_NOTIFY:
-			if (!(cmd->flags & DNET_ATTR_DROP_NOTIFICATION)) {
-				err = dnet_notify_add(st, cmd);
-				/*
-				 * We drop 'need ack' flag, since notification
-				 * transaction is a long-living one, since
-				 * every notification will be sent as transaction
-				 * completion.
-				 *
-				 * Transaction acknowledge will be sent when
-				 * notification is removed.
-				 */
-				if (!err)
-					cmd->flags &= ~DNET_FLAGS_NEED_ACK;
-			} else
-				err = dnet_notify_remove(st, cmd);
+		}
+
+		io = NULL;
+		if (cmd->size < sizeof(struct dnet_io_attr)) {
+			dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid size: cmd: %u, cmd.size: %llu",
+			         dnet_dump_id(&cmd->id), cmd->cmd, (unsigned long long)cmd->size);
+			err = -EINVAL;
 			break;
-		case DNET_CMD_SEND:
-			req = data;
-			dnet_convert_server_send_request(req);
+		}
+		io = data;
+		dnet_convert_io_attr(io);
 
-			if (req->id_num == 0) {
-				dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid send command: id_num must be non zero",
-						dnet_dump_id(&cmd->id));
-				err = -EINVAL;
+		if (n->flags & DNET_CFG_NO_CSUM)
+			io->flags |= DNET_IO_FLAGS_NOCSUM;
+
+		if (!(io->flags & DNET_IO_FLAGS_NOCACHE)) {
+			err = dnet_cmd_cache_io(backend, st, cmd, data, cmd_stats);
+			if (err != -ENOTSUP)
 				break;
-			}
+		}
 
-			if (req->group_num == 0) {
-				dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid send command: group_num must be non zero",
-						dnet_dump_id(&cmd->id));
-				err = -EINVAL;
-				break;
-			}
-
-			size_t req_size = sizeof(struct dnet_server_send_request) +
-						req->id_num * sizeof(struct dnet_raw_id) +
-						req->group_num * sizeof(int);
-
-			if (cmd->size != req_size) {
-				dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid send command: size mismatch: cmd size: %llu, "
-						"request size: %zd",
-						dnet_dump_id(&cmd->id), (unsigned long long)cmd->size, req_size);
-				err = -EINVAL;
-				break;
-			}
-
-			dnet_convert_server_send_request(req);
-			err = backend->cb->command_handler(st, backend->cb->command_private, cmd, data, cmd_stats);
-			break;
-		case DNET_CMD_BULK_READ:
-			err = backend->cb->command_handler(st, backend->cb->command_private, cmd, data, cmd_stats);
-
-			if (err == -ENOTSUP) {
-				err = dnet_cmd_bulk_read(backend, st, cmd, data, cmd_stats);
-			}
-			break;
-		case DNET_CMD_READ:
-		case DNET_CMD_WRITE:
-		case DNET_CMD_DEL:
-			if ((n->ro || backend->read_only) && ((cmd->cmd == DNET_CMD_DEL) || (cmd->cmd == DNET_CMD_WRITE))) {
-				err = -EROFS;
-				break;
-			}
-
-			io = NULL;
-			if (cmd->size < sizeof(struct dnet_io_attr)) {
-				dnet_log(st->n, DNET_LOG_ERROR, "%s: invalid size: cmd: %u, cmd.size: %llu",
-					dnet_dump_id(&cmd->id), cmd->cmd, (unsigned long long)cmd->size);
-				err = -EINVAL;
-				break;
-			}
-			io = data;
-			dnet_convert_io_attr(io);
-
-			if (n->flags & DNET_CFG_NO_CSUM)
-				io->flags |= DNET_IO_FLAGS_NOCSUM;
-
-			if (!(io->flags & DNET_IO_FLAGS_NOCACHE)) {
-				err = dnet_cmd_cache_io(backend, st, cmd, io, data + sizeof(struct dnet_io_attr), cmd_stats);
-
-				if (err != -ENOTSUP) {
+		if (cmd->cmd == DNET_CMD_WRITE) {
+			if (io->flags & DNET_IO_FLAGS_CAS_TIMESTAMP) {
+				err = dnet_cas_timestamp_local(backend, n, io);
+				if (err != 0)
 					break;
-				}
 			}
 
-			if (cmd->cmd == DNET_CMD_WRITE) {
-				if (io->flags & DNET_IO_FLAGS_CAS_TIMESTAMP) {
-					err = dnet_cas_timestamp_local(backend, n, io);
-					if (err != 0)
-						break;
-				}
-
-				if (io->flags & DNET_IO_FLAGS_COMPARE_AND_SWAP) {
-					err = dnet_cas_local(backend, n, &cmd->id, io->parent, DNET_ID_SIZE);
-
-					if (err != 0 && err != -ENOENT)
-						break;
-				}
-			}
-
-			if (io->flags & DNET_IO_FLAGS_CACHE_ONLY)
-				break;
-
-			dnet_convert_io_attr(io);
-		default:
-			if (cmd->cmd == DNET_CMD_LOOKUP && !(cmd->flags & DNET_FLAGS_NOCACHE)) {
-				err = dnet_cmd_cache_lookup(backend, st, cmd, cmd_stats);
-
-				if (err != -ENOTSUP && err != -ENOENT) {
+			if (io->flags & DNET_IO_FLAGS_COMPARE_AND_SWAP) {
+				err = dnet_cas_local(backend, n, &cmd->id, io->parent, DNET_ID_SIZE);
+				if (err != 0 && err != -ENOENT)
 					break;
-				}
 			}
+		}
 
-			if (cmd->cmd == DNET_CMD_LOOKUP_NEW && !(cmd->flags & DNET_FLAGS_NOCACHE)) {
-				err = dnet_cmd_cache_io_new(backend, st, cmd, data, cmd_stats);
-
-				if (err != -ENOTSUP && err != -ENOENT) {
-					break;
-				}
-			}
-
-			if ((n->ro || backend->read_only) && ((cmd->cmd == DNET_CMD_DEL_NEW) || (cmd->cmd == DNET_CMD_WRITE_NEW))) {
-				err = -EROFS;
-				break;
-			}
-
-			if ((cmd->cmd == DNET_CMD_WRITE_NEW) || (cmd->cmd == DNET_CMD_READ_NEW) ||
-			    (cmd->cmd == DNET_CMD_DEL_NEW)) {
-				err = dnet_cmd_cache_io_new(backend, st, cmd, data, cmd_stats);
-
-				if (err != -ENOTSUP) {
-					break;
-				}
-			}
-
-			/* Remove DNET_FLAGS_NEED_ACK flags for READ/WRITE/LOOKUP commands
-			   to eliminate double reply packets
-			   (the first one with dnet_file_info structure or data has been read,
-			   the second to destroy transaction on client side, i.e. packet without DNET_FLAGS_MORE bit) */
-			if ((cmd->cmd == DNET_CMD_WRITE) ||
-			    (cmd->cmd == DNET_CMD_READ) ||
-			    (cmd->cmd == DNET_CMD_LOOKUP) ||
-			    (cmd->cmd == DNET_CMD_WRITE_NEW) ||
-			    (cmd->cmd == DNET_CMD_READ_NEW) ||
-			    (cmd->cmd == DNET_CMD_LOOKUP_NEW)) {
-				cmd->flags &= ~DNET_FLAGS_NEED_ACK;
-			}
-			err = backend->cb->command_handler(st, backend->cb->command_private, cmd, data, cmd_stats);
-
-			if (!err && (cmd->cmd == DNET_CMD_WRITE)) {
-				dnet_update_notify(st, cmd, data);
-			}
+		if (io->flags & DNET_IO_FLAGS_CACHE_ONLY)
 			break;
+
+		dnet_convert_io_attr(io);
+	default:
+		if ((n->ro || dnet_backend_read_only(backend)) &&
+		    ((cmd->cmd == DNET_CMD_DEL_NEW) || (cmd->cmd == DNET_CMD_WRITE_NEW))) {
+			err = -EROFS;
+			break;
+		}
+
+		if (!(cmd->flags & DNET_FLAGS_NOCACHE) &&
+		    ((cmd->cmd == DNET_CMD_LOOKUP) || (cmd->cmd == DNET_CMD_LOOKUP_NEW))) {
+			err = dnet_cmd_cache_io(backend, st, cmd, data, cmd_stats);
+			if (err != -ENOTSUP && err != -ENOENT)
+				break;
+		}
+
+		if ((cmd->cmd == DNET_CMD_WRITE_NEW) ||
+		    (cmd->cmd == DNET_CMD_READ_NEW) ||
+		    (cmd->cmd == DNET_CMD_DEL_NEW)) {
+			err = dnet_cmd_cache_io(backend, st, cmd, data, cmd_stats);
+			if (err != -ENOTSUP)
+				break;
+		}
+
+		/* Remove DNET_FLAGS_NEED_ACK flags for READ/WRITE/LOOKUP commands
+		   to eliminate double reply packets
+		   (the first one with dnet_file_info structure or data has been read,
+		   the second to destroy transaction on client side, i.e. packet without DNET_FLAGS_MORE bit) */
+		if ((cmd->cmd == DNET_CMD_WRITE) ||
+		    (cmd->cmd == DNET_CMD_READ) ||
+		    (cmd->cmd == DNET_CMD_LOOKUP) ||
+		    (cmd->cmd == DNET_CMD_WRITE_NEW) ||
+		    (cmd->cmd == DNET_CMD_READ_NEW) ||
+		    (cmd->cmd == DNET_CMD_LOOKUP_NEW)) {
+			cmd->flags &= ~DNET_FLAGS_NEED_ACK;
+		}
+
+		err = dnet_backend_process_cmd_raw(backend, st, cmd, data, cmd_stats);
+		if (!err && (cmd->cmd == DNET_CMD_WRITE))
+			dnet_update_notify(st, cmd, data);
+		break;
 	}
 
 	gettimeofday(&end, NULL);
@@ -1712,13 +1652,14 @@ static int dnet_process_cmd_with_backend_raw(struct dnet_backend_io *backend, st
 			cmd_stats->size = 0;
 	}
 
-	dnet_backend_command_stats_update(n, backend, cmd, cmd_stats->size, cmd_stats->handled_in_cache, err,
+	dnet_backend_command_stats_update(backend, cmd, cmd_stats->size, cmd_stats->handled_in_cache, err,
 	                                  cmd_stats->handle_time);
+
+	dnet_backend_unlock_state(backend);
 	return err;
 }
 
-int dnet_process_cmd_raw(struct dnet_backend_io *backend,
-                         struct dnet_net_state *st,
+int dnet_process_cmd_raw(struct dnet_net_state *st,
                          struct dnet_cmd *cmd,
                          void *data,
                          int recursive,
@@ -1740,10 +1681,9 @@ int dnet_process_cmd_raw(struct dnet_backend_io *backend,
 
 	gettimeofday(&start, NULL);
 
-	err = dnet_process_cmd_without_backend_raw(st, cmd, data);
-	if (err == -ENOTSUP && backend) {
-		err = dnet_process_cmd_with_backend_raw(backend, st, cmd, data, &cmd_stats);
-	}
+	err = dnet_process_cmd_without_backend_raw(st, cmd, data, &cmd_stats);
+	if (err == -ENOTSUP)
+		err = dnet_process_cmd_with_backend_raw(st, cmd, data, &cmd_stats);
 
 	gettimeofday(&end, NULL);
 	cmd_stats.handle_time = DIFF(start, end);
@@ -1794,6 +1734,9 @@ int dnet_process_cmd_raw(struct dnet_backend_io *backend,
 
 	// we must provide real error from the backend into statistics
 	dnet_monitor_stats_update(n, cmd, err, cmd_stats.handled_in_cache, cmd_stats.size, cmd_stats.handle_time);
+
+	FORMATTED(HANDY_COUNTER_INCREMENT,
+	          ("io.cmd%s.%s.%d", (recursive ? "_recursive" : ""), dnet_cmd_string(cmd->cmd), err), 1);
 
 	err = dnet_send_ack(st, cmd, err, recursive);
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -407,45 +407,6 @@ int dnet_trans_create_send_all(struct dnet_session *s, struct dnet_io_control *c
 	return num;
 }
 
-struct dnet_wait *dnet_wait_alloc(int cond)
-{
-	int err;
-	struct dnet_wait *w;
-
-	w = calloc(1, sizeof(struct dnet_wait));
-	if (!w) {
-		err = -ENOMEM;
-		goto err_out_exit;
-	}
-
-	err = pthread_cond_init(&w->wait, NULL);
-	if (err)
-		goto err_out_exit;
-
-	err = pthread_mutex_init(&w->wait_lock, NULL);
-	if (err)
-		goto err_out_destroy;
-
-	w->cond = cond;
-	atomic_init(&w->refcnt, 1);
-
-	return w;
-
-err_out_destroy:
-	pthread_mutex_destroy(&w->wait_lock);
-	free(w);
-err_out_exit:
-	return NULL;
-}
-
-void dnet_wait_destroy(struct dnet_wait *w)
-{
-	pthread_mutex_destroy(&w->wait_lock);
-	pthread_cond_destroy(&w->wait);
-	free(w->ret);
-	free(w);
-}
-
 struct dnet_addr *dnet_state_addr(struct dnet_net_state *st)
 {
 	return &st->addr;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -768,7 +768,7 @@ int dnet_data_map(struct dnet_map_fd *map);
 int dnet_data_map_rw(struct dnet_map_fd *map);
 void dnet_data_unmap(struct dnet_map_fd *map);
 
-int dnet_ids_update(struct dnet_node *n, int update_local, const char *file, struct dnet_addr *cfg_addrs, size_t backend_id);
+int dnet_ids_update(struct dnet_node *n, int update_local, const char *file, struct dnet_addr *cfg_addrs, uint32_t backend_id);
 
 /*
  * Internal iterator state

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -34,13 +34,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include <eblob/blob.h>
-
-#ifndef HAVE_UCHAR
-typedef unsigned char u_char;
-typedef unsigned short u_short;
-#endif
-
 #include "list.h"
 
 #include "rbtree.h"
@@ -277,57 +270,6 @@ static inline struct dnet_net_state *dnet_state_get(struct dnet_net_state *st)
 	return st;
 }
 
-struct dnet_wait
-{
-	pthread_cond_t		wait;
-	pthread_mutex_t		wait_lock;
-	int			cond;
-	int			status;
-
-	void			*ret;
-	int			size;
-
-	atomic_t		refcnt;
-};
-
-#define dnet_wait_event(w, condition, wts)						\
-({											\
-	int __err = 0;									\
-	struct timespec __ts;								\
- 	struct timeval __tv;								\
-	gettimeofday(&__tv, NULL);							\
-	__ts.tv_nsec = __tv.tv_usec * 1000 + (wts)->tv_nsec;				\
-	__ts.tv_sec = __tv.tv_sec + (wts)->tv_sec;						\
-	pthread_mutex_lock(&(w)->wait_lock);						\
-	while (!(condition) && !__err)							\
-		__err = pthread_cond_timedwait(&(w)->wait, &(w)->wait_lock, &__ts);		\
-	pthread_mutex_unlock(&(w)->wait_lock);						\
-	-__err;										\
-})
-
-#define dnet_wakeup(w, task)								\
-({											\
-	pthread_mutex_lock(&(w)->wait_lock);						\
-	task;										\
-	pthread_cond_broadcast(&(w)->wait);						\
-	pthread_mutex_unlock(&(w)->wait_lock);						\
-})
-
-struct dnet_wait *dnet_wait_alloc(int cond);
-void dnet_wait_destroy(struct dnet_wait *w);
-
-static inline struct dnet_wait *dnet_wait_get(struct dnet_wait *w)
-{
-	atomic_inc(&w->refcnt);
-	return w;
-}
-
-static inline void dnet_wait_put(struct dnet_wait *w)
-{
-	if (atomic_dec_and_test(&w->refcnt))
-		dnet_wait_destroy(w);
-}
-
 struct dnet_notify_bucket
 {
 	struct list_head		notify_list;
@@ -505,7 +447,6 @@ void dnet_config_data_destroy(struct dnet_config_data *config_data);
 
 struct dnet_route_list;
 struct dnet_node {
-	struct list_head	check_entry;
 	struct dnet_transform	transform;
 
 	int			need_exit;
@@ -542,12 +483,10 @@ struct dnet_node {
 
 	dnet_logger		*log;
 
-	struct dnet_wait	*wait;
 	struct timespec		wait_ts;
 
 	struct dnet_io		*io;
 
-	int			check_in_progress;
 	long			check_timeout;
 
 	pthread_t		check_tid;
@@ -705,7 +644,6 @@ int __attribute__((weak)) dnet_process_cmd_raw(struct dnet_net_state *st,
 int dnet_process_recv(struct dnet_net_state *st, struct dnet_io_req *r);
 void dnet_trans_update_timestamp(struct dnet_trans *t);
 
-int dnet_recv(struct dnet_net_state *st, void *data, unsigned int size);
 int dnet_sendfile(struct dnet_net_state *st, int fd, uint64_t *offset, uint64_t size);
 
 int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r);
@@ -813,8 +751,6 @@ void dnet_check_thread_stop(struct dnet_node *n);
 void dnet_reconnect_and_check_route_table(struct dnet_node *node);
 
 int dnet_set_name(const char *format, ...);
-int dnet_ioprio_set(long pid, int class_id, int prio);
-int dnet_ioprio_get(long pid);
 
 struct dnet_map_fd {
 	int			fd;

--- a/library/ids.cpp
+++ b/library/ids.cpp
@@ -25,12 +25,15 @@
 #include "elliptics.h"
 #include "elliptics/interface.h"
 
-#include "../include/elliptics/session.hpp"
+#include "elliptics/session.hpp"
 
-int dnet_ids_update(struct dnet_node *n, int update_local, const char *file, struct dnet_addr *cfg_addrs, size_t backend_id)
-{
+int dnet_ids_update(struct dnet_node *n,
+                    int update_local,
+                    const char *file,
+                    struct dnet_addr *cfg_addrs,
+                    uint32_t backend_id) {
 	char remote_id[1024];
-	sprintf(remote_id, "elliptics_node_ids_%s_%zu", dnet_addr_string(cfg_addrs), backend_id);
+	sprintf(remote_id, "elliptics_node_ids_%s_%" PRIu32, dnet_addr_string(cfg_addrs), backend_id);
 
 	ioremap::elliptics::session session(n);
 

--- a/library/ids.cpp
+++ b/library/ids.cpp
@@ -13,6 +13,9 @@
  * GNU Lesser General Public License for more details.
  */
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 #include <fcntl.h>
 
 #include <vector>

--- a/library/logger.hpp
+++ b/library/logger.hpp
@@ -9,13 +9,17 @@
 
 namespace ioremap { namespace elliptics {
 
-class wrapper_t: public dnet_logger {
+class wrapper_t : public dnet_logger {
 public:
 	wrapper_t(std::unique_ptr<dnet_logger> logger);
 
 	virtual void log(blackhole::severity_t severity, const blackhole::message_t &message);
-	virtual void log(blackhole::severity_t severity, const blackhole::message_t &message, blackhole::attribute_pack &pack);
-	virtual void log(blackhole::severity_t severity, const blackhole::lazy_message_t &message, blackhole::attribute_pack &pack);
+	virtual void log(blackhole::severity_t severity,
+	                 const blackhole::message_t &message,
+	                 blackhole::attribute_pack &pack);
+	virtual void log(blackhole::severity_t severity,
+	                 const blackhole::lazy_message_t &message,
+	                 blackhole::attribute_pack &pack);
 
 	blackhole::scope::manager_t &manager();
 
@@ -23,11 +27,12 @@ public:
 
 	dnet_logger *inner_logger();
 	dnet_logger *base_logger();
+
 private:
 	std::unique_ptr<dnet_logger> m_inner;
 };
 
-class trace_wrapper_t: public wrapper_t {
+class trace_wrapper_t : public wrapper_t {
 public:
 	trace_wrapper_t(std::unique_ptr<dnet_logger> logger);
 	virtual blackhole::attributes_t attributes();
@@ -39,7 +44,7 @@ public:
 	virtual blackhole::attributes_t attributes();
 };
 
-class backend_wrapper_t: public wrapper_t {
+class backend_wrapper_t : public wrapper_t {
 public:
 	backend_wrapper_t(std::unique_ptr<dnet_logger> logger);
 	virtual blackhole::attributes_t attributes();
@@ -47,7 +52,7 @@ public:
 
 dnet_logger *get_base_logger(dnet_logger *logger);
 
-bool log_filter(const blackhole::record_t &record, int level);
+bool log_filter(const blackhole::record_t &record, const int level);
 
 struct trace_scope {
 	explicit trace_scope(uint64_t trace_id, bool trace_bit);
@@ -66,16 +71,16 @@ std::string to_hex_string(uint64_t value);
 extern "C"{
 #endif // __cplusplus
 
-void dnet_node_set_trace_id(uint64_t trace_id, int trace_bit);
-void dnet_node_unset_trace_id();
+void dnet_logger_set_trace_id(uint64_t trace_id, int trace_bit);
+void dnet_logger_unset_trace_id();
 
-uint64_t dnet_node_get_trace_bit();
+uint64_t dnet_logger_get_trace_bit();
+
+void dnet_logger_set_backend_id(int backend_id);
+void dnet_logger_unset_backend_id();
 
 void dnet_logger_set_pool_id(const char *pool_id);
 void dnet_logger_unset_pool_id();
-
-void dnet_node_set_backend_id(int backend_id);
-void dnet_node_unset_backend_id();
 
 void dnet_log_raw(dnet_logger *logger, enum dnet_log_level level, const char *format, ...)
     __attribute__((format(printf, 3, 4)));
@@ -111,7 +116,7 @@ template <class T> inline blackhole::logger_facade<dnet_logger> make_facade(T &&
 
 #define DNET_LOG(__node__, __severity__, ...)								\
 	do {												\
-		if (dnet_node_get_trace_bit() ||							\
+		if (dnet_logger_get_trace_bit() ||							\
 		    (enum dnet_log_level)(__severity__) >= dnet_node_get_verbosity(__node__)) { 	\
 			DNET_LOG_RAW(dnet_node_get_logger(__node__), __severity__, __VA_ARGS__);	\
 		}											\

--- a/library/logger.hpp
+++ b/library/logger.hpp
@@ -54,8 +54,10 @@ dnet_logger *get_base_logger(dnet_logger *logger);
 
 bool log_filter(const blackhole::record_t &record, const int level);
 
+class session;
 struct trace_scope {
 	explicit trace_scope(uint64_t trace_id, bool trace_bit);
+	explicit trace_scope(const session &s);
 	~trace_scope();
 };
 
@@ -65,7 +67,6 @@ struct backend_scope {
 };
 
 std::string to_hex_string(uint64_t value);
-
 }} /* namespace ioremap::elliptics */
 
 extern "C"{
@@ -83,7 +84,7 @@ void dnet_logger_set_pool_id(const char *pool_id);
 void dnet_logger_unset_pool_id();
 
 void dnet_log_raw(dnet_logger *logger, enum dnet_log_level level, const char *format, ...)
-    __attribute__((format(printf, 3, 4)));
+        __attribute__((format(printf, 3, 4)));
 
 dnet_logger *dnet_node_get_logger(struct dnet_node *node);
 

--- a/library/logger.hpp
+++ b/library/logger.hpp
@@ -33,6 +33,12 @@ public:
 	virtual blackhole::attributes_t attributes();
 };
 
+class pool_wrapper_t : public wrapper_t {
+public:
+	pool_wrapper_t(std::unique_ptr<dnet_logger> logger);
+	virtual blackhole::attributes_t attributes();
+};
+
 class backend_wrapper_t: public wrapper_t {
 public:
 	backend_wrapper_t(std::unique_ptr<dnet_logger> logger);
@@ -64,6 +70,9 @@ void dnet_node_set_trace_id(uint64_t trace_id, int trace_bit);
 void dnet_node_unset_trace_id();
 
 uint64_t dnet_node_get_trace_bit();
+
+void dnet_logger_set_pool_id(const char *pool_id);
+void dnet_logger_unset_pool_id();
 
 void dnet_node_set_backend_id(int backend_id);
 void dnet_node_unset_backend_id();

--- a/library/logger.hpp
+++ b/library/logger.hpp
@@ -4,7 +4,6 @@
 
 #ifdef __cplusplus
 #include <atomic>
-#include <blackhole/record.hpp>
 #include <blackhole/extensions/facade.hpp>
 
 namespace ioremap { namespace elliptics {
@@ -52,7 +51,7 @@ public:
 
 dnet_logger *get_base_logger(dnet_logger *logger);
 
-bool log_filter(const blackhole::record_t &record, const int level);
+bool log_filter(const int severity, const int level);
 
 class session;
 struct trace_scope {

--- a/library/net.c
+++ b/library/net.c
@@ -1338,7 +1338,7 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 
 	if (1) {
 		struct dnet_cmd *cmd = r->header ? r->header : r->data;
-		dnet_node_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
+		dnet_logger_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
 		dnet_log(st->n, st->send_offset == 0 ? DNET_LOG_NOTICE : DNET_LOG_DEBUG,
 		         "%s: %s: sending trans: %lld -> %s/%d: size: %llu, cflags: %s, start-sent: %zd/%zd",
 		         dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
@@ -1391,7 +1391,7 @@ err_out_exit:
 		         dnet_addr_string(&st->addr), cmd->backend_id, (unsigned long long)cmd->size,
 		         dnet_flags_dump_cflags(cmd->flags), st->send_offset, total_size);
 	}
-	dnet_node_unset_trace_id();
+	dnet_logger_unset_trace_id();
 
 	if (total_size > sizeof(struct dnet_cmd)) {
 		cork = 0;

--- a/library/net.c
+++ b/library/net.c
@@ -17,6 +17,9 @@
  * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 #include <sys/epoll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -662,7 +665,7 @@ static int dnet_process_control(struct dnet_net_state *st, struct dnet_cmd *cmd,
 	}
 }
 
-int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st, struct dnet_io_req *r)
+int dnet_process_recv(struct dnet_net_state *st, struct dnet_io_req *r)
 {
 	int err = 0;
 	struct dnet_node *n = st->n;
@@ -773,7 +776,7 @@ int dnet_process_recv(struct dnet_backend_io *backend, struct dnet_net_state *st
 		dnet_state_put(forward_state);
 
 		HANDY_COUNTER_INCREMENT("io.cmds", 1);
-		err = dnet_process_cmd_raw(backend, st, cmd, r->data, 0, r->time.tv_sec * 1000000 + r->time.tv_usec);
+		err = dnet_process_cmd_raw(st, cmd, r->data, 0, r->time.tv_sec * 1000000 + r->time.tv_usec);
 	} else {
 		if (!forward_state) {
 			err = -ENXIO;

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -34,6 +34,8 @@
 
 #include <set>
 
+#include <blackhole/attribute.hpp>
+
 #include "elliptics.h"
 #include "elliptics/packet.h"
 #include "elliptics/interface.h"

--- a/library/node.c
+++ b/library/node.c
@@ -670,8 +670,9 @@ void dnet_update_backend_weight(struct dnet_net_state *st, const struct dnet_cmd
 	}
 }
 
-struct dnet_net_state *dnet_state_get_first_with_backend(struct dnet_node *n, const struct dnet_id *id, int *backend_id)
-{
+struct dnet_net_state *dnet_state_get_first_with_backend(struct dnet_node *n,
+                                                         const struct dnet_id *id,
+                                                         int *backend_id) {
 	struct dnet_net_state *found;
 
 	pthread_mutex_lock(&n->state_lock);

--- a/library/pool.c
+++ b/library/pool.c
@@ -997,14 +997,13 @@ static void dnet_io_cleanup_states(struct dnet_node *n)
 	n->st = NULL;
 }
 
-void *dnet_io_process(void *data_)
-{
+void *dnet_io_process(void *data_) {
 	struct dnet_work_io *wio = data_;
 	struct dnet_work_pool *pool = wio->pool;
 	struct dnet_node *n = pool->n;
 	struct dnet_net_state *st;
 	struct dnet_io_req *r;
-	struct dnet_cmd *cmd;
+	struct dnet_cmd *cmd = NULL;
 	int nonblocking = (pool->mode == DNET_WORK_IO_MODE_NONBLOCKING);
 	char thread_stat_id[255];
 

--- a/library/pool.c
+++ b/library/pool.c
@@ -17,6 +17,9 @@
  * along with Elliptics.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 #include <sys/stat.h>
 #include <netinet/in.h>
 
@@ -27,11 +30,13 @@
 #include <signal.h>
 
 #include "elliptics.h"
+#include "backend.h"
 #include "elliptics/interface.h"
 #include "monitor/monitor.h"
 #include "monitor/measure_points.h"
 #include "request_queue.h"
 #include "library/logger.hpp"
+#include "library/backend.h"
 
 static char *dnet_work_io_mode_string[] = {
 	[DNET_WORK_IO_MODE_BLOCKING] = "BLOCKING",
@@ -47,8 +52,7 @@ static char *dnet_work_io_mode_str(int mode)
 	return dnet_work_io_mode_string[mode];
 }
 
-static void dnet_work_pool_stop(struct dnet_work_pool_place *place)
-{
+void dnet_work_pool_stop(struct dnet_work_pool_place *place) {
 	int i;
 	struct dnet_work_io *wio;
 
@@ -89,7 +93,7 @@ static void dnet_work_pool_cleanup(struct dnet_work_pool_place *place)
 
 	pthread_mutex_destroy(&place->pool->lock);
 
-	dnet_request_queue_destroy(place->pool->request_queue);
+	dnet_request_queue_destroy(place->pool);
 
 	free(place->pool->wio_list);
 	free(place->pool);
@@ -157,7 +161,7 @@ err_out_io_threads:
 	return err;
 }
 
-static int dnet_work_pool_place_init(struct dnet_work_pool_place *pool)
+int dnet_work_pool_place_init(struct dnet_work_pool_place *pool)
 {
 	int err;
 	memset(pool, 0, sizeof(struct dnet_work_pool_place));
@@ -172,14 +176,17 @@ err_out_exit:
 	return err;
 }
 
-static void dnet_work_pool_place_cleanup(struct dnet_work_pool_place *pool)
+void dnet_work_pool_place_cleanup(struct dnet_work_pool_place *pool)
 {
 	pthread_mutex_destroy(&pool->lock);
 }
 
-int dnet_work_pool_alloc(struct dnet_work_pool_place *place, struct dnet_node *n,
-	struct dnet_backend_io *io, int num, int mode, void *(* process)(void *))
-{
+int dnet_work_pool_alloc(struct dnet_work_pool_place *place,
+                         struct dnet_node *n,
+                         int num,
+                         int mode,
+                         const char *pool_id,
+                         void *(*process)(void *)) {
 	int err;
 	struct dnet_work_pool *pool;
 
@@ -200,9 +207,10 @@ int dnet_work_pool_alloc(struct dnet_work_pool_place *place, struct dnet_node *n
 	pool->num = 0;
 	pool->mode = mode;
 	pool->n = n;
-	pool->io = io;
 
-	pool->request_queue = dnet_request_queue_create(n, io);
+	strncpy(pool->pool_id, pool_id, sizeof(pool->pool_id));
+
+	pool->request_queue = dnet_request_queue_create();
 	if (!pool->request_queue) {
 		err = -ENOMEM;
 		goto err_out_mutex_destroy;
@@ -251,11 +259,7 @@ static inline void make_thread_stat_id(char *buffer, int size, struct dnet_work_
 	 dnet_work_io_mode_str() provides mode names in uppercase.
 	*/
 	const char *mode_marker = ((pool->mode == DNET_WORK_IO_MODE_BLOCKING) ? "blocking" : "nonblocking");
-	if (pool->io) {
-		snprintf(buffer, size - 1, "%zu.%s", pool->io->backend_id, mode_marker);
-	} else {
-		snprintf(buffer, size - 1, "sys.%s", mode_marker);
-	}
+	snprintf(buffer, size - 1, "%s.%s", pool->pool_id, mode_marker);
 }
 
 static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
@@ -286,11 +290,8 @@ static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
 
 void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 {
-	struct dnet_backend_io *backend_io = NULL;
 	struct dnet_work_pool_place *place = NULL;
-	struct dnet_work_pool_place *backend_place = NULL;
 	struct dnet_work_pool *pool = NULL;
-	struct dnet_io_pool *io_pool = &n->io->pool;
 	struct dnet_cmd *cmd = r->header;
 	int nonblocking = !!(cmd->flags & DNET_FLAGS_NOLOCK);
 	ssize_t backend_id = -1;
@@ -318,44 +319,13 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 
 	dnet_update_trans_timestamp_network(r);
 
-	if (cmd->flags & DNET_FLAGS_DIRECT_BACKEND)
+	if (cmd->flags & DNET_FLAGS_DIRECT_BACKEND) {
 		backend_id = cmd->backend_id;
-	else if (dnet_cmd_needs_backend(cmd->cmd))
+	} else if (dnet_cmd_needs_backend(cmd->cmd)) {
 		backend_id = dnet_state_search_backend(n, &cmd->id);
-
-	if (backend_id >= 0) {
-		backend_io = dnet_get_backend_io(n->io, backend_id);
 	}
 
-	if (backend_io) {
-		io_pool = &backend_io->pool;
-		if (nonblocking) {
-			place = &io_pool->recv_pool_nb;
-		} else {
-			place = &io_pool->recv_pool;
-		}
-
-		if (place) {
-			pthread_mutex_lock(&place->lock);
-			if (!place->pool) {
-				pthread_mutex_unlock(&place->lock);
-				io_pool = &n->io->pool;
-				place = NULL;
-			}
-		}
-	}
-
-	backend_place = place;
-
-	if (place == NULL) {
-		if (nonblocking) {
-			place = &io_pool->recv_pool_nb;
-		} else {
-			place = &io_pool->recv_pool;
-		}
-
-		pthread_mutex_lock(&place->lock);
-	}
+	place = dnet_backend_get_place(n, backend_id, nonblocking);
 
 	pool = place->pool;
 
@@ -363,17 +333,11 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 
 	// If we are processing the command we should update cmd->backend_id to actual one
 	if (!(cmd->flags & DNET_FLAGS_REPLY)) {
-		if (pool->io)
-			cmd->backend_id = pool->io->backend_id;
-		else
-			cmd->backend_id = -1;
+		cmd->backend_id = backend_id >= 0 ? backend_id : -1;
 	}
 
-	dnet_log(n, DNET_LOG_DEBUG, "%s: %s: backend_id: %zd, place: %p, backend_place: %p, "
-			"backend_place->pool->backend_id: %zd, cmd->backend_id: %d",
-		dnet_state_dump_addr(r->st), dnet_dump_id(r->header), backend_id, place, backend_place,
-		backend_place && backend_place->pool->io ? (ssize_t)backend_place->pool->io->backend_id : (ssize_t)-1,
-		cmd->backend_id);
+	dnet_log(n, DNET_LOG_DEBUG, "%s: %s: backend_id: %zd, place: %p, cmd->backend_id: %d",
+	         dnet_state_dump_addr(r->st), dnet_dump_id(r->header), backend_id, place, cmd->backend_id);
 
 	dnet_push_request(pool, r);
 
@@ -840,8 +804,7 @@ static void dnet_check_work_pool_place(struct dnet_work_pool_place *place, uint6
 	pthread_mutex_unlock(&place->lock);
 }
 
-static void dnet_check_io_pool(struct dnet_io_pool *io, uint64_t *queue_size, uint64_t *threads_count)
-{
+void dnet_check_io_pool(struct dnet_io_pool *io, uint64_t *queue_size, uint64_t *threads_count) {
 	dnet_check_work_pool_place(&io->recv_pool, queue_size, threads_count);
 	dnet_check_work_pool_place(&io->recv_pool_nb, queue_size, threads_count);
 }
@@ -850,19 +813,11 @@ static int dnet_check_io(struct dnet_io *io)
 {
 	uint64_t queue_size = 0;
 	uint64_t threads_count = 0;
-	size_t i;
 
 	dnet_check_io_pool(&io->pool, &queue_size, &threads_count);
 
-	pthread_rwlock_rdlock(&io->backends_lock);
-	if (io->backends) {
-		for (i = 0; i < io->backends_count; ++i) {
-			if (io->backends[i]) {
-				dnet_check_io_pool(&io->backends[i]->pool, &queue_size, &threads_count);
-			}
-		}
-	}
-	pthread_rwlock_unlock(&io->backends_lock);
+	if (io->pools_manager)
+		dnet_io_pools_check(io->pools_manager, &queue_size, &threads_count);
 
 	if (queue_size <= threads_count * 1000)
 		return 1;
@@ -904,6 +859,7 @@ static void *dnet_io_process_network(void *data_)
 	struct timeval prev_tv, curr_tv;
 
 	dnet_set_name("dnet_net");
+	dnet_logger_set_pool_id("net");
 
 	dnet_log(n, DNET_LOG_NOTICE, "started net pool");
 
@@ -1021,6 +977,7 @@ static void *dnet_io_process_network(void *data_)
 
 err_out_exit:
 	dnet_log(n, DNET_LOG_NOTICE, "finished net pool");
+	dnet_logger_unset_pool_id();
 	return &n->need_exit;
 }
 
@@ -1051,23 +1008,16 @@ void *dnet_io_process(void *data_)
 	int nonblocking = (pool->mode == DNET_WORK_IO_MODE_NONBLOCKING);
 	char thread_stat_id[255];
 
-	if (pool->io) {
-		dnet_set_name("dnet_%sio_%zu", nonblocking ? "nb_" : "", pool->io->backend_id);
-	} else {
-		dnet_set_name("dnet_%sio", nonblocking ? "nb_" : "");
-	}
+	dnet_set_name("dnet_%sio_%s", nonblocking ? "nb_" : "", pool->pool_id);
 
 	make_thread_stat_id(thread_stat_id, sizeof(thread_stat_id), pool);
 
-	if (pool->io) {
-		dnet_node_set_backend_id(pool->io->backend_id);
-	}
+	dnet_logger_set_pool_id(pool->pool_id);
 
-	dnet_log(n, DNET_LOG_NOTICE, "started io thread: #%d, nonblocking: %d, backend: %zd",
-		wio->thread_index, nonblocking, pool->io ? (ssize_t)pool->io->backend_id : -1);
+	dnet_log(n, DNET_LOG_NOTICE, "started io thread: #%d, nonblocking: %d, pool: %s", wio->thread_index,
+	         nonblocking, pool->pool_id);
 
-
-	while (!n->need_exit && (!pool->io || !pool->io->need_exit)) {
+	while (!n->need_exit && !pool->need_exit) {
 		r = dnet_pop_request(wio, thread_stat_id);
 		if (!r)
 			continue;
@@ -1079,30 +1029,34 @@ void *dnet_io_process(void *data_)
 		st = r->st;
 		cmd = r->header;
 
+		dnet_node_set_backend_id(cmd->backend_id);
 		dnet_node_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
 
-		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: got IO event: %p: cmd: %s, hsize: %zu, dsize: %zu, mode: %s, backend_id: %zd, queue_time: %ld usecs",
-			dnet_state_dump_addr(st), dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd), r->hsize, r->dsize, dnet_work_io_mode_str(pool->mode),
-			pool->io ? (ssize_t)pool->io->backend_id : (ssize_t)-1, (r->time.tv_sec * 1000000 + r->time.tv_usec));
+		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: got IO event: %p: cmd: %s, hsize: %zu, dsize: %zu, mode: %s, "
+		                            "backend_id: %d, queue_time: %ld usecs",
+		         dnet_state_dump_addr(st), dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd), r->hsize,
+		         r->dsize, dnet_work_io_mode_str(pool->mode), cmd->backend_id,
+		         (r->time.tv_sec * 1000000 + r->time.tv_usec));
 
-		dnet_process_recv(pool->io, st, r);
+		dnet_process_recv(st, r);
 
-		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: processed IO event: %p, cmd: %s",
-			dnet_state_dump_addr(st), dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd));
-
-		dnet_node_unset_trace_id();
+		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: processed IO event: %p, cmd: %s", dnet_state_dump_addr(st),
+		         dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd));
 
 		dnet_release_request(wio, r);
 		dnet_io_req_free(r);
 		dnet_state_put(st);
 
+		dnet_node_unset_trace_id();
+		dnet_node_unset_backend_id();
+
 		FORMATTED(HANDY_COUNTER_DECREMENT, ("pool.%s.active_threads", thread_stat_id), 1);
 	}
 
-	dnet_log(n, DNET_LOG_NOTICE, "finished io thread: #%d, nonblocking: %d, backend: %zd",
-		wio->thread_index, pool->mode == DNET_WORK_IO_MODE_NONBLOCKING, pool->io ? (ssize_t)pool->io->backend_id : -1);
+	dnet_log(n, DNET_LOG_NOTICE, "finished io thread: #%d, nonblocking: %d, pool: %s", wio->thread_index,
+	         pool->mode == DNET_WORK_IO_MODE_NONBLOCKING, pool->pool_id);
 
-	dnet_node_unset_backend_id();
+	dnet_logger_unset_pool_id();
 
 	return NULL;
 }
@@ -1131,12 +1085,6 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 		goto err_out_free_mutex;
 	}
 
-	err = pthread_rwlock_init(&n->io->backends_lock, NULL);
-	if (err) {
-		err = -err;
-		goto err_out_free_cond;
-	}
-
 	list_stat_init(&n->io->output_stats);
 
 	n->io->net_thread_num = cfg->net_thread_num;
@@ -1145,10 +1093,11 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 
 	err = dnet_work_pool_place_init(&n->io->pool.recv_pool);
 	if (err) {
-		goto err_out_free_backends_lock;
+		goto err_out_free_cond;
 	}
 
-	err = dnet_work_pool_alloc(&n->io->pool.recv_pool, n, NULL, cfg->io_thread_num, DNET_WORK_IO_MODE_BLOCKING, dnet_io_process);
+	err = dnet_work_pool_alloc(&n->io->pool.recv_pool, n, cfg->io_thread_num, DNET_WORK_IO_MODE_BLOCKING, "sys",
+	                           dnet_io_process);
 	if (err) {
 		goto err_out_cleanup_recv_place;
 	}
@@ -1158,7 +1107,8 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 		goto err_out_free_recv_pool;
 	}
 
-	err = dnet_work_pool_alloc(&n->io->pool.recv_pool_nb, n, NULL, cfg->nonblocking_io_thread_num, DNET_WORK_IO_MODE_NONBLOCKING, dnet_io_process);
+	err = dnet_work_pool_alloc(&n->io->pool.recv_pool_nb, n, cfg->nonblocking_io_thread_num,
+	                           DNET_WORK_IO_MODE_NONBLOCKING, "sys", dnet_io_process);
 	if (err) {
 		goto err_out_cleanup_recv_place_nb;
 	}
@@ -1204,8 +1154,6 @@ err_out_free_recv_pool:
 	dnet_work_pool_exit(&n->io->pool.recv_pool);
 err_out_cleanup_recv_place:
 	dnet_work_pool_place_cleanup(&n->io->pool.recv_pool);
-err_out_free_backends_lock:
-	pthread_rwlock_destroy(&n->io->backends_lock);
 err_out_free_cond:
 	pthread_cond_destroy(&n->io->full_wait);
 err_out_free_mutex:
@@ -1217,147 +1165,11 @@ err_out_exit:
 	return err;
 }
 
-int dnet_server_backend_init(struct dnet_node *n, size_t backend_id)
-{
-	int err;
-	const size_t new_count = backend_id + 1;
-	struct dnet_backend_io **backends_tmp;
-	struct dnet_backend_io *io;
-
-	pthread_rwlock_wrlock(&n->io->backends_lock);
-	if (new_count > n->io->backends_count || !n->io->backends[backend_id]) {
-		io = calloc(1, sizeof(struct dnet_backend_io));
-		if (!io) {
-			err = -ENOMEM;
-			goto err_out_unlock;
-		}
-
-		io->backend_id = backend_id;
-
-		err = dnet_work_pool_place_init(&io->pool.recv_pool);
-		if (err) {
-			goto err_out_free;
-		}
-
-		err = dnet_work_pool_place_init(&io->pool.recv_pool_nb);
-		if (err) {
-			dnet_work_pool_place_cleanup(&io->pool.recv_pool);
-			goto err_out_free;
-		}
-
-		if (new_count > n->io->backends_count) {
-			backends_tmp = realloc(n->io->backends, new_count * sizeof(struct dnet_backend_io *));
-			if (backends_tmp) {
-				memset(backends_tmp + n->io->backends_count, 0,
-				       (new_count - n->io->backends_count) * sizeof(struct dnet_backend_io *));
-				n->io->backends = backends_tmp;
-				n->io->backends_count = new_count;
-			} else {
-				err = -ENOMEM;
-				goto err_out_free;
-			}
-		}
-
-		n->io->backends[backend_id] = io;
-	}
-	pthread_rwlock_unlock(&n->io->backends_lock);
-
-	return 0;
-
-err_out_free:
-	free(io);
-err_out_unlock:
-	pthread_rwlock_unlock(&n->io->backends_lock);
-	return err;
-}
-
-int dnet_server_io_init(struct dnet_node *n)
-{
-	int err;
-	size_t j = 0, k = 0;
-	size_t *backend_ids, num_backend_ids;
-	size_t backends_count;
-
-        err = dnet_get_backend_ids(n->config_data->backends, &backend_ids, &num_backend_ids);
-	if (err) {
-		goto err_out_exit;
-	}
-
-	backends_count = backend_ids[0];
-	for (j = 1; j < num_backend_ids; ++j) {
-		if (backend_ids[j] > backends_count)
-			backends_count = backend_ids[j];
-	}
-	++backends_count;
-
-	n->io->backends_count = backends_count;
-	n->io->backends = calloc(backends_count, sizeof(struct dnet_backend_io *));
-	if (!n->io->backends) {
-		err = -ENOMEM;
-		goto err_out_free_backend_ids;
-	}
-
-	for (j = 0; j < num_backend_ids; ++j) {
-		struct dnet_backend_io *io = calloc(1, sizeof(struct dnet_backend_io));
-		if (!io) {
-			err = -ENOMEM;
-			goto err_out_free_backends_io;
-		}
-
-		io->backend_id = backend_ids[j];
-
-		err = dnet_work_pool_place_init(&io->pool.recv_pool);
-		if (err) {
-			free(io);
-			goto err_out_free_backends_io;
-		}
-
-		err = dnet_work_pool_place_init(&io->pool.recv_pool_nb);
-		if (err) {
-			free(io);
-			dnet_work_pool_place_cleanup(&io->pool.recv_pool);
-			goto err_out_free_backends_io;
-		}
-
-		n->io->backends[io->backend_id] = io;
-	}
-
-	free(backend_ids);
-	return 0;
-
-err_out_free_backends_io:
-	for (k = 0; k < j; ++k) {
-		struct dnet_backend_io *backend_io = n->io->backends[backend_ids[k]];
-		backend_io->need_exit = 1;
-	}
-	for (k = 0; k < j; ++k) {
-		struct dnet_backend_io *backend_io = n->io->backends[backend_ids[k]];
-		dnet_work_pool_exit(&backend_io->pool.recv_pool);
-		dnet_work_pool_exit(&backend_io->pool.recv_pool_nb);
-		free(backend_io);
-	}
-	free(n->io->backends);
-	n->io->backends = NULL;
-err_out_free_backend_ids:
-	free(backend_ids);
-err_out_exit:
-	return err;
-}
-
-void dnet_io_stop(struct dnet_node *n)
-{
+void dnet_io_stop(struct dnet_node *n) {
 	struct dnet_io *io = n->io;
 	int i;
-	size_t j;
 
 	dnet_set_need_exit(n);
-
-	for (j = 0; j < n->io->backends_count; ++j) {
-		struct dnet_backend_io *backend_io = n->io->backends[j];
-		if (backend_io) {
-			backend_io->need_exit = 1;
-		}
-	}
 
 	for (i = 0; i < io->net_thread_num; ++i) {
 		pthread_join(io->net[i].tid, NULL);
@@ -1366,22 +1178,11 @@ void dnet_io_stop(struct dnet_node *n)
 
 	dnet_work_pool_stop(&io->pool.recv_pool_nb);
 	dnet_work_pool_stop(&io->pool.recv_pool);
-
-	for (j = 0; j < io->backends_count; ++j) {
-		struct dnet_backend_io *backend_io = io->backends[j];
-		if (backend_io) {
-			if (backend_io->pool.recv_pool.pool)
-				dnet_work_pool_stop(&backend_io->pool.recv_pool);
-			if (backend_io->pool.recv_pool_nb.pool)
-				dnet_work_pool_stop(&backend_io->pool.recv_pool_nb);
-		}
-	}
 }
 
 void dnet_io_cleanup(struct dnet_node *n)
 {
 	struct dnet_io *io = n->io;
-	size_t i;
 
 	dnet_work_pool_cleanup(&io->pool.recv_pool_nb);
 	dnet_work_pool_place_cleanup(&io->pool.recv_pool_nb);
@@ -1389,22 +1190,8 @@ void dnet_io_cleanup(struct dnet_node *n)
 	dnet_work_pool_cleanup(&io->pool.recv_pool);
 	dnet_work_pool_place_cleanup(&io->pool.recv_pool);
 
-	for (i = 0; i < io->backends_count; ++i) {
-		struct dnet_backend_io *backend_io = io->backends[i];
-		if (backend_io) {
-			if (backend_io->pool.recv_pool.pool)
-				dnet_work_pool_cleanup(&backend_io->pool.recv_pool);
-			if (backend_io->pool.recv_pool_nb.pool)
-				dnet_work_pool_cleanup(&backend_io->pool.recv_pool_nb);
-			dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool_nb);
-			dnet_work_pool_place_cleanup(&backend_io->pool.recv_pool);
-
-			free(backend_io);
-			io->backends[i] = NULL;
-		}
-	}
-	free(io->backends);
-	io->backends = NULL;
+	if (io->backends_manager || io->pools_manager)
+		dnet_backends_destroy(n);
 
 	dnet_io_cleanup_states(n);
 

--- a/library/pool.c
+++ b/library/pool.c
@@ -376,7 +376,7 @@ static int dnet_process_recv_single(struct dnet_net_state *st)
 	uint64_t size;
 	int err;
 
-	dnet_node_set_trace_id(st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT);
+	dnet_logger_set_trace_id(st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT);
 again:
 	/*
 	 * Reading command first.
@@ -409,8 +409,8 @@ again:
 			goto out;
 		}
 
-		dnet_node_unset_trace_id();
-		dnet_node_set_trace_id(st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT);
+		dnet_logger_unset_trace_id();
+		dnet_logger_set_trace_id(st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT);
 
 		if ((st->rcv_flags & DNET_IO_CMD) && (st->rcv_offset == 0)) {
 			gettimeofday(&st->rcv_start_tv, NULL);
@@ -472,14 +472,14 @@ again:
 	r->st = dnet_state_get(st);
 
 	dnet_schedule_io(n, r);
-	dnet_node_unset_trace_id();
+	dnet_logger_unset_trace_id();
 	return 0;
 
 out:
 	if (err != -EAGAIN && err != -EINTR)
 		dnet_schedule_command(st);
 
-	dnet_node_unset_trace_id();
+	dnet_logger_unset_trace_id();
 	return err;
 }
 
@@ -1029,8 +1029,8 @@ void *dnet_io_process(void *data_)
 		st = r->st;
 		cmd = r->header;
 
-		dnet_node_set_backend_id(cmd->backend_id);
-		dnet_node_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
+		dnet_logger_set_backend_id(cmd->backend_id);
+		dnet_logger_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
 
 		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: got IO event: %p: cmd: %s, hsize: %zu, dsize: %zu, mode: %s, "
 		                            "backend_id: %d, queue_time: %ld usecs",
@@ -1047,8 +1047,8 @@ void *dnet_io_process(void *data_)
 		dnet_io_req_free(r);
 		dnet_state_put(st);
 
-		dnet_node_unset_trace_id();
-		dnet_node_unset_backend_id();
+		dnet_logger_unset_trace_id();
+		dnet_logger_unset_backend_id();
 
 		FORMATTED(HANDY_COUNTER_DECREMENT, ("pool.%s.active_threads", thread_stat_id), 1);
 	}

--- a/library/protocol.cpp
+++ b/library/protocol.cpp
@@ -2,7 +2,7 @@
 
 #include <msgpack.hpp>
 
-#include "monitor/rapidjson/document.h"
+#include "rapidjson/document.h"
 
 namespace msgpack {
 using namespace ioremap::elliptics;

--- a/library/request_queue.cpp
+++ b/library/request_queue.cpp
@@ -322,24 +322,16 @@ void dnet_oplock_guard::unlock()
 	}
 }
 
-
-void dnet_push_request(struct dnet_work_pool *pool, struct dnet_io_req *req)
-{
-	auto queue = reinterpret_cast<dnet_request_queue*>(pool->request_queue);
-	queue->push_request(req);
+void dnet_push_request(struct dnet_work_pool *pool, struct dnet_io_req *req) {
+	pool->request_queue->push_request(req);
 }
 
-struct dnet_io_req *dnet_pop_request(struct dnet_work_io *wio, const char *thread_stat_id)
-{
-	struct dnet_work_pool *pool = wio->pool;
-	auto queue = reinterpret_cast<dnet_request_queue*>(pool->request_queue);
-	return queue->pop_request(wio, thread_stat_id);
+struct dnet_io_req *dnet_pop_request(struct dnet_work_io *wio, const char *thread_stat_id) {
+	return wio->pool->request_queue->pop_request(wio, thread_stat_id);
 }
 
-void dnet_release_request(struct dnet_work_io *wio, const struct dnet_io_req *req)
-{
-	auto queue = reinterpret_cast<dnet_request_queue*>(wio->pool->request_queue);
-	queue->release_request(req);
+void dnet_release_request(struct dnet_work_io *wio, const struct dnet_io_req *req) {
+	wio->pool->request_queue->release_request(req);
 }
 
 void dnet_oplock(struct dnet_io_pool *pool, const struct dnet_id *id) {
@@ -351,8 +343,7 @@ void dnet_opunlock(struct dnet_io_pool *pool, const struct dnet_id *id) {
 }
 
 size_t dnet_get_pool_queue_size(struct dnet_work_pool *pool) {
-	auto queue = reinterpret_cast<dnet_request_queue*>(pool->request_queue);
-	return queue->size();
+	return pool->request_queue->size();
 }
 
 void *dnet_request_queue_create() {

--- a/library/route.cpp
+++ b/library/route.cpp
@@ -1,4 +1,7 @@
 #include "route.h"
+
+#include <blackhole/attribute.hpp>
+
 #include "elliptics.h"
 #include <elliptics/utils.hpp>
 #include "logger.hpp"

--- a/library/route.cpp
+++ b/library/route.cpp
@@ -213,7 +213,7 @@ struct dnet_backend_update_cmd
 	dnet_backend_ids ids;
 };
 
-int dnet_route_list::enable_backend(size_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count)
+int dnet_route_list::enable_backend(uint32_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count)
 {
 	dnet_cmd *cmd = reinterpret_cast<dnet_cmd *>(malloc(sizeof(dnet_backend_update_cmd) + ids_count * sizeof(dnet_raw_id)));
 	if (!cmd)
@@ -239,7 +239,7 @@ int dnet_route_list::enable_backend(size_t backend_id, int group_id, dnet_raw_id
 
 	std::lock_guard<std::mutex> lock_guard(m_mutex);
 
-	m_backends.resize(std::max(m_backends.size(), backend_id + 1));
+	m_backends.resize(std::max(m_backends.size(), size_t(backend_id + 1)));
 
 	backend_info &backend = m_backends[backend_id];
 	backend.activated = true;
@@ -251,7 +251,7 @@ int dnet_route_list::enable_backend(size_t backend_id, int group_id, dnet_raw_id
 	return err;
 }
 
-int dnet_route_list::disable_backend(size_t backend_id)
+int dnet_route_list::disable_backend(uint32_t backend_id)
 {
 	std::lock_guard<std::mutex> lock_guard(m_mutex);
 
@@ -360,7 +360,7 @@ int dnet_route_list::send_all_ids_nolock(dnet_net_state *st, dnet_id *id,
 
 	char *ptr = reinterpret_cast<char *>(id_container + 1);
 
-	for (size_t backend_id = 0; backend_id < m_backends.size(); ++backend_id) {
+	for (uint32_t backend_id = 0; backend_id < m_backends.size(); ++backend_id) {
 		backend_info &backend = m_backends[backend_id];
 		if (!backend.activated)
 			continue;
@@ -390,7 +390,7 @@ int dnet_route_list::send_all_ids_nolock(dnet_net_state *st, dnet_id *id,
 	return dnet_send(st, buffer, total_size);
 }
 
-void dnet_route_list::send_update_to_states(dnet_cmd *cmd, size_t backend_id)
+void dnet_route_list::send_update_to_states(dnet_cmd *cmd, uint32_t backend_id)
 {
 	dnet_net_state *state;
 	dnet_pthread_lock_guard guard(m_node->state_lock);
@@ -414,7 +414,7 @@ void dnet_route_list::send_update_to_states(dnet_cmd *cmd, size_t backend_id)
 	}
 }
 
-dnet_route_list *dnet_route_list_create(dnet_node *node)
+struct dnet_route_list *dnet_route_list_create(dnet_node *node)
 {
 	try {
 		return new dnet_route_list(node);
@@ -423,7 +423,7 @@ dnet_route_list *dnet_route_list_create(dnet_node *node)
 	}
 }
 
-void dnet_route_list_destroy(dnet_route_list *route)
+void dnet_route_list_destroy(struct dnet_route_list *route)
 {
 	delete route;
 }
@@ -443,12 +443,12 @@ int dnet_state_join(struct dnet_net_state *st)
 	return safe_call(st->n->route, &dnet_route_list::join, st);
 }
 
-int dnet_route_list_enable_backend(dnet_route_list *route, size_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count)
+int dnet_route_list_enable_backend(struct dnet_route_list *route, uint32_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count)
 {
 	return safe_call(route, &dnet_route_list::enable_backend, backend_id, group_id, ids, ids_count);
 }
 
-int dnet_route_list_disable_backend(dnet_route_list *route, size_t backend_id)
+int dnet_route_list_disable_backend(struct dnet_route_list *route, uint32_t backend_id)
 {
 	return safe_call(route, &dnet_route_list::disable_backend, backend_id);
 }

--- a/library/route.h
+++ b/library/route.h
@@ -15,8 +15,8 @@ public:
 	dnet_route_list(dnet_node *node);
 	~dnet_route_list();
 
-	int enable_backend(size_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count);
-	int disable_backend(size_t backend_id);
+	int enable_backend(uint32_t backend_id, int group_id, dnet_raw_id *ids, size_t ids_count);
+	int disable_backend(uint32_t backend_id);
 
 	int on_reverse_lookup(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data);
 	int on_join(struct dnet_net_state *st, struct dnet_cmd *cmd, void *data);
@@ -25,7 +25,7 @@ public:
 	int send_all_ids_nolock(dnet_net_state *st, struct dnet_id *id, uint64_t trans,
 		unsigned int command, int reply, int direct);
 protected:
-	void send_update_to_states(dnet_cmd *cmd, size_t backend_id);
+	void send_update_to_states(dnet_cmd *cmd, uint32_t backend_id);
 
 private:
 	dnet_node *m_node;
@@ -46,14 +46,14 @@ private:
 
 extern "C" {
 #else // __cplusplus
-typedef struct dnet_route_list_t dnet_route_list;
+struct dnet_route_list;
 #endif // __cplusplus
 
-dnet_route_list *dnet_route_list_create(struct dnet_node *node);
-void dnet_route_list_destroy(dnet_route_list *route);
+struct dnet_route_list *dnet_route_list_create(struct dnet_node *node);
+void dnet_route_list_destroy(struct dnet_route_list *route);
 
-int dnet_route_list_enable_backend(dnet_route_list *route, size_t backend_id, int group_id, struct dnet_raw_id *ids, size_t ids_count);
-int dnet_route_list_disable_backend(dnet_route_list *route, size_t backend_id);
+int dnet_route_list_enable_backend(struct dnet_route_list *route, uint32_t backend_id, int group_id, struct dnet_raw_id *ids, size_t ids_count);
+int dnet_route_list_disable_backend(struct dnet_route_list *route, uint32_t backend_id);
 
 int dnet_route_list_send_all_ids_nolock(struct dnet_net_state *st, struct dnet_id *id, uint64_t trans,
 	unsigned int command, int reply, int direct);

--- a/library/trans.c
+++ b/library/trans.c
@@ -244,7 +244,7 @@ void dnet_trans_destroy(struct dnet_trans *t)
 	if (!t)
 		return;
 
-	dnet_node_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
+	dnet_logger_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
 
 	gettimeofday(&tv, NULL);
 	diff = 1000000 * (tv.tv_sec - t->start.tv_sec) + (tv.tv_usec - t->start.tv_usec);
@@ -312,7 +312,7 @@ void dnet_trans_destroy(struct dnet_trans *t)
 	dnet_state_put(t->st);
 	dnet_state_put(t->orig);
 
-	dnet_node_unset_trace_id();
+	dnet_logger_unset_trace_id();
 	free(t);
 }
 
@@ -462,13 +462,13 @@ void dnet_trans_clean_list(struct list_head *head, int error)
 		t->cmd.flags &= ~DNET_FLAGS_REPLY;
 		t->cmd.status = error;
 
-		dnet_node_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
+		dnet_logger_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
 		if (t->complete) {
 			t->complete(dnet_state_addr(t->st), &t->cmd, t->priv);
 		}
 
 		dnet_trans_put(t);
-		dnet_node_unset_trace_id();
+		dnet_logger_unset_trace_id();
 	}
 }
 
@@ -554,7 +554,7 @@ int dnet_trans_iterate_move_transaction(struct dnet_net_state *st, struct list_h
 
 		// TODO: We may use dnet_log_record_set_request_id here,
 		// but blackhole currently has higher priority for scoped attributes =(
-		dnet_node_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
+		dnet_logger_set_trace_id(t->cmd.trace_id, t->cmd.flags & DNET_FLAGS_TRACE_BIT);
 
 		dnet_log(st->n, DNET_LOG_ERROR, "%s: %s: TIMEOUT/need-exit %s, "
 				"need-exit: %d, started: %s.%06lu",
@@ -590,7 +590,7 @@ int dnet_trans_iterate_move_transaction(struct dnet_net_state *st, struct list_h
 		}
 
 		list_add_tail(&t->trans_list_entry, head);
-		dnet_node_unset_trace_id();
+		dnet_logger_unset_trace_id();
 
 		pthread_mutex_unlock(&st->trans_lock);
 	}

--- a/monitor/backends_stat_provider.cpp
+++ b/monitor/backends_stat_provider.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "backends_stat_provider.hpp"
+
+#include <blackhole/attribute.hpp>
+
 #include "statistics.hpp"
 
 #include "library/elliptics.h"
@@ -36,278 +39,27 @@ backends_stat_provider::backends_stat_provider(struct dnet_node *node)
 {}
 
 /*
- * Gets statistics from lowlevel backend and writes it to "backend" section
- */
-static void fill_backend_backend(rapidjson::Value &stat_value,
-                                 rapidjson::Document::AllocatorType &allocator,
-                                 const struct dnet_backend_io *backend,
-                                 const dnet_backend_info *config_backend) {
-	char *json_stat = nullptr;
-	size_t size = 0;
-	struct dnet_backend_callbacks *cb = backend->cb;
-	if (cb->storage_stat_json) {
-		cb->storage_stat_json(cb->command_private, &json_stat, &size);
-		if (json_stat && size) {
-			rapidjson::Document backend_value(&allocator);
-			backend_value.Parse<0>(json_stat);
-			auto &config_value = backend_value["config"];
-			config_value.AddMember("group", config_backend->group, allocator);
-			config_value.AddMember("queue_timeout", config_backend->queue_timeout, allocator);
-
-			rapidjson::Document initial_config(&allocator);
-			initial_config.Parse<0>(config_backend->initial_config.c_str());
-			backend_value.AddMember("initial_config",
-			                        static_cast<rapidjson::Value&>(initial_config),
-			                        allocator);
-
-			stat_value.AddMember("backend",
-			                     static_cast<rapidjson::Value&>(backend_value),
-			                     allocator);
-		}
-	}
-
-	free(json_stat);
-}
-
-/*
- * Fills io section of one backend
- */
-static void fill_backend_io(rapidjson::Value &stat_value,
-                            rapidjson::Document::AllocatorType &allocator,
-                            const struct dnet_backend_io *backend) {
-	rapidjson::Value io_value(rapidjson::kObjectType);
-
-	rapidjson::Value blocking_stat(rapidjson::kObjectType);
-	auto size = dnet_get_pool_queue_size(backend->pool.recv_pool.pool);
-	blocking_stat.AddMember("current_size", size, allocator);
-	io_value.AddMember("blocking", blocking_stat, allocator);
-
-	rapidjson::Value nonblocking_stat(rapidjson::kObjectType);
-	size = dnet_get_pool_queue_size(backend->pool.recv_pool_nb.pool);
-	nonblocking_stat.AddMember("current_size", size, allocator);
-	io_value.AddMember("nonblocking", nonblocking_stat, allocator);
-
-	stat_value.AddMember("io", io_value, allocator);
-}
-
-/*
- * Fills cache section of one backend
- */
-static void fill_backend_cache(rapidjson::Value &stat_value,
-                               rapidjson::Document::AllocatorType &allocator,
-                               const struct dnet_backend_io *backend) {
-	if (backend->cache) {
-		ioremap::cache::cache_manager *cache = (ioremap::cache::cache_manager *)backend->cache;
-		rapidjson::Document caches_value(&allocator);
-		caches_value.Parse<0>(cache->stat_json().c_str());
-		stat_value.AddMember("cache",
-		                     static_cast<rapidjson::Value&>(caches_value),
-		                     allocator);
-	}
-}
-
-/*
- * Fills status section of one backend
- */
-static void fill_backend_status(rapidjson::Value &stat_value,
-                                rapidjson::Document::AllocatorType &allocator,
-                                struct dnet_node *node,
-                                dnet_backend_status &status,
-                                const dnet_backend_info *config_backend) {
-	backend_fill_status_nolock(node, &status, config_backend);
-
-	rapidjson::Value status_value(rapidjson::kObjectType);
-	status_value.AddMember("state", status.state, allocator);
-	status_value.AddMember("string_state", dnet_backend_state_string(status.state), allocator);
-	status_value.AddMember("defrag_state", status.defrag_state, allocator);
-	status_value.AddMember("string_defrag_state", dnet_backend_defrag_state_string(status.defrag_state), allocator);
-
-	rapidjson::Value last_start(rapidjson::kObjectType);
-	last_start.AddMember("tv_sec", status.last_start.tsec, allocator);
-	last_start.AddMember("tv_usec", status.last_start.tnsec / 1000, allocator);
-	status_value.AddMember("last_start", last_start, allocator);
-
-	status_value.AddMember("string_last_time", dnet_print_time(&status.last_start), allocator);
-	status_value.AddMember("last_start_err", status.last_start_err, allocator);
-	status_value.AddMember("read_only", status.read_only == 1, allocator);
-	status_value.AddMember("delay", status.delay, allocator);
-
-	stat_value.AddMember("status", status_value, allocator);
-}
-
-/*
- * This function is called to fill in config values read from the config for non-enabled (yet) backends.
- *
- * If config template provides API for serializing parsed config values to json
- * it fills 'backend::config' section otherwise it uses unparsed values from original config
- * and fills 'backend::config_template'.
- *
- * After backend has been enabled, @fill_backend_backend() is called instead.
- */
-static void fill_disabled_backend_config(rapidjson::Value &stat_value,
-                                         rapidjson::Document::AllocatorType &allocator,
-                                         const dnet_backend_info *config_backend) {
-	rapidjson::Value backend_value(rapidjson::kObjectType);
-
-	/* If config template provides API for serializing parsed config values to json - use it */
-	if (config_backend->config_template.to_json) {
-		char *json_stat = nullptr;
-		size_t size = 0;
-
-		dnet_config_backend config = config_backend->config_template;
-		std::vector<char> data(config.size, '\0');
-		config.data = data.data();
-		config.log = config_backend->log.get();
-
-		for (auto it = config_backend->options.begin(); it != config_backend->options.end(); ++it) {
-			const dnet_backend_config_entry &entry = *it;
-			entry.entry->callback(&config, entry.entry->key, entry.value_template.data());
-		}
-
-		config.to_json(&config, &json_stat, &size);
-		if (json_stat && size) {
-			rapidjson::Document config_value(&allocator);
-			config_value.Parse<0>(json_stat);
-			config_value.AddMember("group", config_backend->group, allocator);
-			backend_value.AddMember("config",
-			                        static_cast<rapidjson::Value&>(config_value),
-			                        allocator);
-		}
-		free(json_stat);
-		config.cleanup(&config);
-	} else {
-		rapidjson::Value config_value(rapidjson::kObjectType);
-		for (auto it = config_backend->options.begin(); it != config_backend->options.end(); ++it) {
-			const dnet_backend_config_entry &entry = *it;
-
-			rapidjson::Value tmp_val(entry.value_template.data(), allocator);
-			config_value.AddMember(entry.entry->key, tmp_val, allocator);
-		}
-		config_value.AddMember("group", config_backend->group, allocator);
-		backend_value.AddMember("config_template", config_value, allocator);
-	}
-
-	stat_value.AddMember("backend", backend_value, allocator);
-}
-
-/*
- * Fills all sections of one backend
- */
-static rapidjson::Value& backend_stats_json(uint64_t categories,
-                                            rapidjson::Value &stat_value,
-                                            rapidjson::Document::AllocatorType &allocator,
-                                            struct dnet_node *node,
-                                            const dnet_backend_info *config_backend) {
-	dnet_backend_status status;
-	memset(&status, 0, sizeof(status));
-
-	auto backend_id = config_backend->backend_id;
-	stat_value.AddMember("backend_id", backend_id, allocator);
-	fill_backend_status(stat_value, allocator, node, status, config_backend);
-
-	struct dnet_backend_io *backend_io = nullptr;
-	if (status.state == DNET_BACKEND_ENABLED && node->io) {
-		backend_io = dnet_get_backend_io(node->io, backend_id);
-	}
-
-	if (backend_io) {
-		if (categories & DNET_MONITOR_COMMANDS) {
-			const command_stats *stats = (command_stats *)(backend_io->command_stats);
-			rapidjson::Value commands_value(rapidjson::kObjectType);
-			stat_value.AddMember("commands", stats->commands_report(nullptr, commands_value, allocator),
-					     allocator);
-		}
-
-		if (categories & DNET_MONITOR_BACKEND) {
-			fill_backend_backend(stat_value, allocator, backend_io, config_backend);
-		}
-		if (categories & DNET_MONITOR_IO) {
-			fill_backend_io(stat_value, allocator, backend_io);
-		}
-		if (categories & DNET_MONITOR_CACHE) {
-			fill_backend_cache(stat_value, allocator, backend_io);
-		}
-	} else if (categories & DNET_MONITOR_BACKEND) {
-		fill_disabled_backend_config(stat_value, allocator, config_backend);
-	}
-
-	return stat_value;
-}
-
-/*
- * Fills all section of all backends
- */
-static void backends_stats_json(uint64_t categories,
-                                rapidjson::Value &stat_value,
-                                rapidjson::Document::AllocatorType &allocator,
-                                struct dnet_node *node) {
-	auto backends = node->config_data->backends->get_all_backends();
-	for (auto &backend_ptr : backends) {
-		auto config_backend = backend_ptr.get();
-		auto backend_id = config_backend->backend_id;
-
-		std::lock_guard<std::mutex> guard(*config_backend->state_mutex);
-		if (config_backend->state != DNET_BACKEND_UNITIALIZED) {
-			rapidjson::Value backend_stat(rapidjson::kObjectType);
-			stat_value.AddMember(std::to_string(static_cast<unsigned long long>(backend_id)).c_str(),
-					     allocator,
-					     backend_stats_json(categories, backend_stat, allocator, node, config_backend),
-					     allocator);
-		}
-	}
-}
-
-/*
  * Generates json statistics from all backends
  */
-std::string backends_stat_provider::json(uint64_t categories) const {
-	if (!(categories & DNET_MONITOR_IO) &&
-	    !(categories & DNET_MONITOR_CACHE) &&
-	    !(categories & DNET_MONITOR_BACKEND))
-	    return std::string();
+void backends_stat_provider::statistics(uint64_t categories,
+                                        rapidjson::Value &value,
+                                        rapidjson::Document::AllocatorType &allocator) const {
+	if (!(categories & (DNET_MONITOR_IO | DNET_MONITOR_CACHE | DNET_MONITOR_BACKEND)))
+		return;
 
-	rapidjson::Document doc;
-	doc.SetObject();
-	auto &allocator = doc.GetAllocator();
-
-	backends_stats_json(categories, doc, allocator, m_node);
-
-	rapidjson::StringBuffer buffer;
-	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	doc.Accept(writer);
-	return buffer.GetString();
+	m_node->io->backends_manager->statistics(categories, value, allocator);
 }
 
 }} /* namespace ioremap::monitor */
 
-int dnet_backend_command_stats_init(struct dnet_backend_io *backend_io)
-{
-	int err = 0;
+void dnet_backend_command_stats_update(struct dnet_backend *backend,
+                                       struct dnet_cmd *cmd,
+                                       uint64_t size,
+                                       int handled_in_cache,
+                                       int err,
+                                       long diff) {
+	if (!backend)
+		return;
 
-	try {
-		backend_io->command_stats = (void *)(new ioremap::monitor::command_stats());
-	} catch (...) {
-		backend_io->command_stats = nullptr;
-		err = -ENOMEM;
-	}
-
-	return err;
-}
-
-void dnet_backend_command_stats_cleanup(struct dnet_backend_io *backend_io)
-{
-	delete reinterpret_cast<ioremap::monitor::command_stats *>(backend_io->command_stats);
-	backend_io->command_stats = nullptr;
-}
-
-void dnet_backend_command_stats_update(struct dnet_node *node, struct dnet_backend_io *backend_io,
-		struct dnet_cmd *cmd, uint64_t size, int handled_in_cache, int err, long diff)
-{
-	auto stats = reinterpret_cast<ioremap::monitor::command_stats *>(backend_io->command_stats);
-
-	assert(stats != nullptr);
-
-	(void) node;
-
-	stats->command_counter(cmd->cmd, cmd->trans, err, handled_in_cache, size, diff);
+	backend->command_stats().command_counter(cmd->cmd, cmd->trans, err, handled_in_cache, size, diff);
 }

--- a/monitor/backends_stat_provider.hpp
+++ b/monitor/backends_stat_provider.hpp
@@ -33,7 +33,9 @@ class backends_stat_provider : public stat_provider {
 public:
 	backends_stat_provider(struct dnet_node *node);
 
-	virtual std::string json(uint64_t categories) const;
+	void statistics(uint64_t categories,
+	                        rapidjson::Value &value,
+	                        rapidjson::Document::AllocatorType &allocator) const override;
 
 private:
 	struct dnet_node *m_node;

--- a/monitor/io_stat_provider.hpp
+++ b/monitor/io_stat_provider.hpp
@@ -23,6 +23,7 @@
 #include "stat_provider.hpp"
 
 struct dnet_node;
+struct dnet_io_pool;
 
 namespace ioremap { namespace monitor {
 
@@ -30,12 +31,17 @@ class io_stat_provider: public stat_provider {
 public:
 	io_stat_provider(dnet_node *n): m_node(n) {}
 
-	virtual std::string json(uint64_t categories) const;
+	void statistics(uint64_t categories,
+	                        rapidjson::Value &value,
+	                        rapidjson::Document::AllocatorType &allocator) const override;
 
 private:
 	dnet_node *m_node;
 };
 
+void dump_io_pool_stats(struct dnet_io_pool &io_pool,
+                        rapidjson::Value &value,
+                        rapidjson::Document::AllocatorType &allocator);
 }} /* namespace ioremap::monitor */
 
 #endif /* __DNET_MONITOR_IO_STAT_PROVIDER_HPP */

--- a/monitor/monitor.cpp
+++ b/monitor/monitor.cpp
@@ -21,10 +21,15 @@
 #include "monitor.hpp"
 #include "compress.hpp"
 
+#include <blackhole/attribute.hpp>
+
 #include <exception>
 #include <iostream>
 
+#include <kora/config.hpp>
+
 #include "library/elliptics.h"
+#include "library/logger.hpp"
 #include "io_stat_provider.hpp"
 #include "backends_stat_provider.hpp"
 #include "procfs_provider.hpp"
@@ -212,15 +217,6 @@ void dnet_monitor_exit(struct dnet_node *n) {
 	if (real_monitor) {
 		n->monitor = NULL;
 		delete real_monitor;
-	}
-}
-
-void dnet_monitor_add_provider(struct dnet_node *n, struct stat_provider_raw stat, const char *name) {
-	try {
-		auto provider = new ioremap::monitor::raw_provider(stat);
-		ioremap::monitor::add_provider(n, provider, std::string(name));
-	} catch (const std::exception &e) {
-		std::cerr << e.what() << std::endl;
 	}
 }
 

--- a/monitor/monitor.cpp
+++ b/monitor/monitor.cpp
@@ -52,8 +52,7 @@ monitor *get_monitor(struct dnet_node *n) {
 }
 
 monitor_config* get_monitor_config(struct dnet_node *n) {
-	const auto& data = *static_cast<const ioremap::elliptics::config::config_data *>(n->config_data);
-	return data.monitor_config.get();
+	return dnet_node_get_config_data(n)->monitor_config.get();
 }
 
 std::unique_ptr<monitor_config> monitor_config::parse(const kora::config_t &monitor) {
@@ -70,9 +69,8 @@ std::unique_ptr<monitor_config> monitor_config::parse(const kora::config_t &moni
 		cfg->has_top = (cfg->top_length > 0) && (cfg->events_size > 0) && (cfg->period_in_seconds > 0);
 	}
 
-	if (monitor.has("handystats")) {
+	if (monitor.has("handystats"))
 		cfg->handystats = kora::to_json(monitor.underlying_object());
-	}
 	return cfg;
 }
 
@@ -128,13 +126,6 @@ void add_provider(struct dnet_node *n, stat_provider *provider, const std::strin
 		real_monitor->get_statistics().add_provider(provider, name);
 	else
 		delete provider;
-}
-
-void remove_provider(dnet_node *n, const std::string &name)
-{
-	auto real_monitor = get_monitor(n);
-	if (real_monitor)
-		real_monitor->get_statistics().remove_provider(name);
 }
 
 static void init_io_stat_provider(struct dnet_node *n) {
@@ -218,10 +209,6 @@ void dnet_monitor_exit(struct dnet_node *n) {
 		n->monitor = NULL;
 		delete real_monitor;
 	}
-}
-
-void dnet_monitor_remove_provider(struct dnet_node *n, const char *name) {
-	ioremap::monitor::remove_provider(n, std::string(name));
 }
 
 void dnet_monitor_stats_update(struct dnet_node *n,

--- a/monitor/monitor.h
+++ b/monitor/monitor.h
@@ -33,40 +33,6 @@ struct dnet_config;
 /*!
  * \internal
  *
- * Raw statistics provider which can be used from c code
- */
-struct stat_provider_raw {
-
-	/*!
-	 * \internal
-	 *
-	 * User-defined private data for provider
-	 */
-	void		*stat_private;
-
-	/*!
-	 * \internal
-	 *
-	 * Callback which returns current statistics of provider in json format
-	 * It will be called only when was requested for statistics
-	 * \a priv - user-defined private data for provider
-	 * \a categories - categories which statistics should be included to json
-	 */
-	const char*	(* json) (void *priv, uint64_t categories);
-
-	/*!
-	 * \internal
-	 *
-	 * Callback for stopping and clearing provider's data.
-	 * It will be called once when the provider is no longer required
-	 * \a priv - user-defined private data for provider
-	 */
-	void		(* stop) (void *priv);
-};
-
-/*!
- * \internal
- *
  * Initializes monitoring with specified configuration
  * If monitor would be successfully initialized
  * then n->monitor will contain pointer to it and
@@ -80,14 +46,6 @@ int dnet_monitor_init(struct dnet_node *n, struct dnet_config *cfg);
  * Unitializes monitor and resets n->monitor to 0
  */
 void dnet_monitor_exit(struct dnet_node *n);
-
-/*!
- * \internal
- *
- * Adds to \a monitor raw statistics provider \a stat
- * with \a name to the provider list
- */
-void dnet_monitor_add_provider(struct dnet_node *n, struct stat_provider_raw stat, const char *name);
 
 /*!
  * \internal

--- a/monitor/monitor.h
+++ b/monitor/monitor.h
@@ -49,12 +49,6 @@ void dnet_monitor_exit(struct dnet_node *n);
 
 /*!
  * \internal
- * Removes statistics provider by \a name from \a monitor.
- */
-void dnet_monitor_remove_provider(struct dnet_node *n, const char *name);
-
-/*!
- * \internal
  *
  * Sends to \a monitor statistics some properties of executed command:
  * \a cmd - identifier of the command

--- a/monitor/monitor.hpp
+++ b/monitor/monitor.hpp
@@ -25,6 +25,10 @@
 
 struct dnet_node;
 
+namespace kora {
+class config_t;
+} /* namespace kora */
+
 namespace ioremap { namespace monitor {
 
 struct monitor_config {

--- a/monitor/procfs_provider.cpp
+++ b/monitor/procfs_provider.cpp
@@ -19,8 +19,12 @@
 
 #include "procfs_provider.hpp"
 
+#include <blackhole/attribute.hpp>
+
+#include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
+
 #include "elliptics/interface.h"
 
 #include "library/logger.hpp"
@@ -296,23 +300,17 @@ static void fill_net(dnet_node *node,
 	stat_value.AddMember("net", net_stat, allocator);
 }
 
-std::string procfs_provider::json(uint64_t categories) const {
+void procfs_provider::statistics(uint64_t categories,
+                                 rapidjson::Value &value,
+                                 rapidjson::Document::AllocatorType &allocator) const {
 	if (!(categories & DNET_MONITOR_PROCFS))
-	    return std::string();
+	    return;
 
-	rapidjson::Document doc;
-	doc.SetObject();
-	auto &allocator = doc.GetAllocator();
-
-	fill_vm(m_node, doc, allocator);
-	fill_io(m_node, doc, allocator);
-	fill_stat(m_node, doc, allocator);
-	fill_net(m_node, doc, allocator);
-
-	rapidjson::StringBuffer buffer;
-	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	doc.Accept(writer);
-	return buffer.GetString();
+	value.SetObject();
+	fill_vm(m_node, value, allocator);
+	fill_io(m_node, value, allocator);
+	fill_stat(m_node, value, allocator);
+	fill_net(m_node, value, allocator);
 }
 
 

--- a/monitor/procfs_provider.hpp
+++ b/monitor/procfs_provider.hpp
@@ -31,7 +31,9 @@ class procfs_provider : public stat_provider {
 public:
 	procfs_provider(struct dnet_node *node);
 
-	virtual std::string json(uint64_t categories) const;
+	void statistics(uint64_t categories,
+	                rapidjson::Value &value,
+	                rapidjson::Document::AllocatorType &allocator) const override;
 
 private:
 	struct dnet_node *m_node;

--- a/monitor/server.cpp
+++ b/monitor/server.cpp
@@ -22,6 +22,8 @@
 
 #include <chrono>
 
+#include <blackhole/attribute.hpp>
+
 #include "library/elliptics.h"
 #include "library/logger.hpp"
 #include "http_miscs.hpp"

--- a/monitor/stat_provider.hpp
+++ b/monitor/stat_provider.hpp
@@ -20,7 +20,7 @@
 #ifndef __DNET_STAT_PROVIDER_HPP
 #define __DNET_STAT_PROVIDER_HPP
 
-#include <string>
+#include "rapidjson/document.h"
 
 namespace ioremap { namespace monitor {
 
@@ -40,7 +40,9 @@ public:
 	 * Returns json string of the real provider statistics
 	 * \a categories - categories which statistics should be included to json
 	 */
-	virtual std::string json(uint64_t categories) const = 0;
+	virtual void statistics(uint64_t categories,
+	                        rapidjson::Value &value,
+	                        rapidjson::Document::AllocatorType &allocator) const = 0;
 
 	/*!
 	 * \internal

--- a/monitor/statistics.cpp
+++ b/monitor/statistics.cpp
@@ -40,15 +40,17 @@
 namespace ioremap { namespace monitor {
 
 static void ext_stat_json(const ext_counter &ext_stat,
-		rapidjson::Value &stat_value, rapidjson::Document::AllocatorType &allocator) {
+                          rapidjson::Value &stat_value,
+                          rapidjson::Document::AllocatorType &allocator) {
 	stat_value.AddMember("successes", ext_stat.counter.successes, allocator);
 	stat_value.AddMember("failures", ext_stat.counter.failures, allocator);
 	stat_value.AddMember("size", ext_stat.size, allocator);
 	stat_value.AddMember("time", ext_stat.time, allocator);
 }
 
-static void source_stat_json(const source_counter &source_stat, rapidjson::Value &stat_value,
-		rapidjson::Document::AllocatorType &allocator) {
+static void source_stat_json(const source_counter &source_stat,
+                             rapidjson::Value &stat_value,
+                             rapidjson::Document::AllocatorType &allocator) {
 	rapidjson::Value outside_stat(rapidjson::kObjectType);
 	ext_stat_json(source_stat.outside, outside_stat, allocator);
 	stat_value.AddMember("outside", outside_stat, allocator);
@@ -200,12 +202,6 @@ void statistics::add_provider(stat_provider *stat, const std::string &name)
 	m_stat_providers.insert(make_pair(name, std::shared_ptr<stat_provider>(stat)));
 }
 
-void statistics::remove_provider(const std::string &name)
-{
-	std::unique_lock<std::mutex> guard(m_provider_mutex);
-	m_stat_providers.erase(name);
-}
-
 inline std::string convert_report(const rapidjson::Document &report)
 {
 	rapidjson::StringBuffer buffer;
@@ -231,6 +227,7 @@ std::string statistics::report(uint64_t categories)
 	report.AddMember("string_timestamp", dnet_print_time(&time), allocator);
 
 	report.AddMember("monitor_status", "enabled", allocator);
+	report.AddMember("categories", categories, allocator);
 
 	if (categories & DNET_MONITOR_COMMANDS) {
 		rapidjson::Value commands_value(rapidjson::kObjectType);

--- a/monitor/statistics.hpp
+++ b/monitor/statistics.hpp
@@ -28,7 +28,7 @@
 
 #include "rapidjson/document.h"
 
-#include "../library/elliptics.h"
+#include "library/elliptics.h"
 
 #include "monitor.h"
 #include "stat_provider.hpp"
@@ -182,25 +182,10 @@ public:
 	 * external statistics provider
 	 */
 	void add_provider(stat_provider *stat, const std::string &name);
-	void remove_provider(const std::string &name);
 
 	typedef std::shared_ptr<top_stats> top_stats_ptr;
 	top_stats_ptr get_top_stats() const { return m_top_stats; }
 private:
-	/*!
-	 * \internal
-	 * Fills \a stat_value by usefull vm statistics and returns it
-	 * \a allocator - document allocator that is required by rapidjson
-	 */
-	rapidjson::Value& vm_report(rapidjson::Value &stat_value,
-	                            rapidjson::Document::AllocatorType &allocator);
-
-	rapidjson::Value& proc_io_report(rapidjson::Value &stat_value,
-	                                 rapidjson::Document::AllocatorType &allocator);
-
-	rapidjson::Value& proc_stat(rapidjson::Value &stat_value,
-	                            rapidjson::Document::AllocatorType &allocator);
-
 	/*!
 	 * \internal
 	 *

--- a/monitor/statistics.hpp
+++ b/monitor/statistics.hpp
@@ -39,47 +39,6 @@ namespace ioremap { namespace monitor {
 
 class monitor;
 
-/*!
- * \internal
- *
- * Raw provide which wraps C provider for using in statistics
- */
-class raw_provider : public stat_provider {
-public:
-
-	/*!
-	 * \internal
-	 *
-	 * Constructor: initializes provider by C provider \a stat
-	 */
-	raw_provider(stat_provider_raw stat)
-	: m_stat(stat)
-	{}
-
-	/*!
-	 * \internal
-	 *
-	 * Destructor: calls stopping C provider
-	 */
-	virtual ~raw_provider() {
-		m_stat.stop(m_stat.stat_private);
-	}
-
-	/*!
-	 * \internal
-	 *
-	 * Returns json string of the real provider statistics
-	 * \a categories - categories which statistics should be included to json
-	 */
-	virtual std::string json(uint64_t categories) const {
-		auto json = m_stat.json(m_stat.stat_private, categories);
-		return json ? json : std::string();
-	}
-
-private:
-	stat_provider_raw	m_stat;
-};
-
 struct base_counter {
 	uint64_t successes;
 	uint64_t failures;
@@ -138,6 +97,8 @@ class command_stats {
 public:
 	command_stats();
 
+	void clear();
+
 	/*!
 	 * Adds executed command properties to different command statistics
 	 * \a cmd - identifier of the command
@@ -154,8 +115,9 @@ public:
 	 * Fills \a a stat_value by commands statistics and returns it
 	 * \a allocator - document allocator that is required by rapidjson
 	 */
-	rapidjson::Value& commands_report(dnet_node *node, rapidjson::Value &stat_value,
-	                                  rapidjson::Document::AllocatorType &allocator) const;
+	void commands_report(dnet_node *node,
+	                     rapidjson::Value &stat_value,
+	                     rapidjson::Document::AllocatorType &allocator) const;
 
 private:
 	/*!

--- a/monitor/top.cpp
+++ b/monitor/top.cpp
@@ -19,9 +19,6 @@
 
 #include "top.hpp"
 
-#include "rapidjson/document.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
 #include "elliptics/interface.h"
 
 namespace ioremap { namespace monitor {
@@ -60,13 +57,13 @@ static void fill_top_stat(const key_stat_event &key_event,
 	stat_array.PushBack(key_stat, allocator);
 }
 
-std::string top_provider::json(uint64_t categories) const {
+void top_provider::statistics(uint64_t categories,
+                              rapidjson::Value &value,
+                              rapidjson::Document::AllocatorType &allocator) const {
 	if (!(categories & DNET_MONITOR_TOP))
-		return std::string();
+		return;
 
-	rapidjson::Document doc;
-	doc.SetObject();
-	auto &allocator = doc.GetAllocator();
+	value.SetObject();
 
 	std::vector<key_stat_event> top_size_keys;
 	auto& event_stats = m_top_stats->get_stats();
@@ -80,14 +77,9 @@ std::string top_provider::json(uint64_t categories) const {
 		fill_top_stat(key_stat, stat_array, allocator);
 	}
 
-	doc.AddMember("top_result_limit", m_top_stats->get_top_length(), allocator);
-	doc.AddMember("period_in_seconds", m_top_stats->get_period(), allocator);
-	doc.AddMember("top_by_size", stat_array, allocator);
-
-	rapidjson::StringBuffer buffer;
-	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	doc.Accept(writer);
-	return buffer.GetString();
+	value.AddMember("top_result_limit", m_top_stats->get_top_length(), allocator);
+	value.AddMember("period_in_seconds", m_top_stats->get_period(), allocator);
+	value.AddMember("top_by_size", stat_array, allocator);
 }
 
 }} /* namespace ioremap::monitor */

--- a/monitor/top.hpp
+++ b/monitor/top.hpp
@@ -130,7 +130,9 @@ class top_provider : public stat_provider {
 public:
 	top_provider(std::shared_ptr<top_stats> top_stats);
 
-	virtual std::string json(uint64_t categories) const;
+	void statistics(uint64_t categories,
+	                rapidjson::Value &value,
+	                rapidjson::Document::AllocatorType &allocator) const override;
 
 private:
 	std::shared_ptr<top_stats> m_top_stats;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,11 @@ set_target_properties(dnet_new_api_test ${TEST_PROPERTIES})
 target_link_libraries(dnet_new_api_test ${TEST_LIBRARIES})
 add_test_target(test_new_api dnet_new_api_test DEPENDS ${TESTS_DEPS})
 
+add_executable(dnet_io_pools_test io_pools_test.cpp)
+set_target_properties(dnet_io_pools_test ${TEST_PROPERTIES})
+target_link_libraries(dnet_io_pools_test ${TEST_LIBRARIES})
+add_test_target(test_io_pools dnet_io_pools_test DEPENDS ${TESTS_DEPS})
+
 add_executable(dnet_new_api_iterator_test new_api_iterator_test.cpp)
 set_target_properties(dnet_new_api_iterator_test ${TEST_PROPERTIES})
 target_link_libraries(dnet_new_api_iterator_test ${TEST_LIBRARIES})
@@ -200,6 +205,7 @@ set(TESTS_LIST
     dnet_new_api_test
     dnet_new_api_server_send_test
     dnet_forwarding_test
+    dnet_io_pools_test
 )
 
 #

--- a/tests/backends_test.cpp
+++ b/tests/backends_test.cpp
@@ -490,10 +490,10 @@ static void test_change_group(session &sess)
 	unique_hosts = get_unique_hosts(sess);
 
 	BOOST_REQUIRE_MESSAGE(unique_hosts.find(old_tuple) == unique_hosts.end(),
-		"Host must not exist: " + host + ", group: 2, backend: 1");
+		"Host must not exist: " + host + ", group: 2, backend: " + std::to_string(backend_id));
 
 	BOOST_REQUIRE_MESSAGE(unique_hosts.find(new_tuple) != unique_hosts.end(),
-		"Host must not exist: " + host + ", group: 10, backend: 1");
+		"Host must exist: " + host + ", group: 10, backend: " + std::to_string(backend_id));
 }
 
 static void test_check_initial_config(session &sess) {

--- a/tests/backends_test.cpp
+++ b/tests/backends_test.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "test_base.hpp"
-#include "../library/elliptics.h"
+#include "library/elliptics.h"
 #include <algorithm>
 
 #include <kora/dynamic.hpp>

--- a/tests/cache_test.cpp
+++ b/tests/cache_test.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "test_base.hpp"
-#include "../cache/cache.hpp"
+#include "cache/cache.hpp"
+#include "library/backend.h"
+
+#include "library/backend.h"
 
 #include <list>
 #include <stdexcept>
@@ -78,8 +81,8 @@ static void test_cache_timestamp(session &sess)
 static void test_cache_records_sizes(session &sess, const nodes_data *setup)
 {
 	dnet_node *node = setup->nodes[0].get_native();
-	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
-	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
+	auto backend = node->io->backends_manager->get(0);
+	auto cache = backend->cache();
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 	argument_data data("0");
@@ -113,8 +116,8 @@ static void test_cache_records_sizes(session &sess, const nodes_data *setup)
 static void test_cache_overflow(session &sess, const nodes_data *setup)
 {
 	dnet_node *node = setup->nodes[0].get_native();
-	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
-	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
+	auto backend = node->io->backends_manager->get(0);
+	auto cache = backend->cache();
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 	argument_data data("0");
@@ -236,8 +239,8 @@ void cache_read_check_lru(session &sess, int id, lru_list_emulator_t &lru_list_e
 static void test_cache_lru_eviction(session &sess, const nodes_data *setup)
 {
 	dnet_node *node = setup->nodes[0].get_native();
-	dnet_backend_io *backend_io = dnet_get_backend_io(node->io, 0);
-	ioremap::cache::cache_manager *cache = reinterpret_cast<ioremap::cache::cache_manager *>(backend_io->cache);
+	auto backend = node->io->backends_manager->get(0);
+	auto cache = backend->cache();
 	const size_t cache_size = cache->cache_size();
 	const size_t cache_pages_number = cache->cache_pages_number();
 

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <cstdio>
 #include "test_base.hpp"
-#include "../library/crypto/sha512.h"
+#include "library/crypto/sha512.h"
 
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API

--- a/tests/io_pools_test.cpp
+++ b/tests/io_pools_test.cpp
@@ -1,0 +1,416 @@
+#include <fstream>
+
+#include <kora/dynamic.hpp>
+
+#include <boost/program_options.hpp>
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+#include <boost/test/included/unit_test.hpp>
+
+#include "test_base.hpp"
+
+using namespace tests;
+namespace bu = boost::unit_test;
+
+nodes_data::ptr configure_test_setup(const std::string &path) {
+	auto server_config = []() {
+		auto ret = server_config::default_value();
+		ret.backends.clear();
+		return ret;
+	} ();
+
+	start_nodes_config config(bu::results_reporter::get_stream(), {server_config}, path);
+	config.fork = true;
+
+	return start_nodes(config);
+}
+
+static uint32_t backend_to_group(uint32_t backend_id) {
+	return 1000 + backend_id;
+}
+
+static void enable_backend(ioremap::elliptics::newapi::session &s, const nodes_data *setup, uint32_t backend_id) {
+	auto remote = setup->nodes.front().remote();
+	ELLIPTICS_REQUIRE(async, s.enable_backend(remote, backend_id));
+	BOOST_REQUIRE_EQUAL(async.get().size(), 1);
+}
+
+static void disable_backend(ioremap::elliptics::newapi::session &s, const nodes_data *setup, uint32_t backend_id) {
+	auto remote = setup->nodes.front().remote();
+	ELLIPTICS_REQUIRE(async, s.disable_backend(remote, backend_id));
+	BOOST_REQUIRE_EQUAL(async.get().size(), 1);
+}
+
+static void remove_backend(ioremap::elliptics::newapi::session &s, const nodes_data *setup, uint32_t backend_id) {
+	auto remote = setup->nodes.front().remote();
+	ELLIPTICS_REQUIRE(async, s.remove_backend(remote, backend_id));
+	BOOST_REQUIRE_EQUAL(async.get().size(), 1);
+}
+
+static void check_statistics(ioremap::elliptics::newapi::session &s,
+                             std::vector<std::tuple<uint32_t, std::string>> enabled_backends,
+                             std::vector<std::tuple<uint32_t, std::string>> disabled_backends) {
+	if (enabled_backends.empty())
+		// routes should be empty if no backends are enabled
+		BOOST_REQUIRE_EQUAL(s.get_routes().size(), 0);
+
+	ELLIPTICS_REQUIRE(async, s.monitor_stat(DNET_MONITOR_IO | DNET_MONITOR_BACKEND));
+	auto results = async.get();
+	BOOST_REQUIRE_EQUAL(results.size(), 1); // the only node is run
+
+	auto statistics = [&results]() {
+		auto json = results[0].statistics();
+		std::istringstream stream(json);
+		return kora::dynamic::read_json(stream);
+	}();
+	BOOST_REQUIRE(statistics.is_object());
+
+	const auto &backends = statistics.as_object()["backends"];
+	BOOST_REQUIRE(backends.is_object());
+	BOOST_REQUIRE_EQUAL(backends.as_object().size(), enabled_backends.size() + disabled_backends.size());
+
+	auto check_backend = [&backends](const std::tuple<uint32_t, std::string> tuple, bool enabled) {
+		const auto backend_id = std::get<0>(tuple);
+		const auto &pool_id = std::get<1>(tuple).empty() ? std::to_string(backend_id) : std::get<1>(tuple);
+
+		const auto &backend = backends.as_object()[std::to_string(backend_id)];
+		BOOST_REQUIRE(backend.is_object());
+		BOOST_REQUIRE_EQUAL(backend.as_object()["backend_id"].as_uint(), backend_id);
+
+		const auto &status = backend.as_object()["status"];
+		BOOST_REQUIRE(status.is_object());
+		BOOST_REQUIRE_EQUAL(status.as_object()["backend_id"].as_uint(), backend_id);
+		BOOST_REQUIRE_EQUAL(status.as_object()["state"].as_uint(),
+		                    enabled ? DNET_BACKEND_ENABLED : DNET_BACKEND_DISABLED);
+		BOOST_REQUIRE_EQUAL(status.as_object()["pool_id"].as_string(), enabled ? pool_id : "");
+		BOOST_REQUIRE_EQUAL(status.as_object()["group"].as_uint(), backend_to_group(backend_id));
+
+		if (!enabled) {
+			BOOST_REQUIRE(backend.as_object().find("io") == backend.as_object().end());
+			return;
+		}
+
+		const auto &io = backend.as_object()["io"];
+		BOOST_REQUIRE(io.is_object());
+
+		const auto &blocking = io.as_object()["blocking"];
+		BOOST_REQUIRE(blocking.is_object());
+		BOOST_REQUIRE_EQUAL(blocking.as_object()["current_size"].as_uint(), 0);
+
+		const auto &nonblocking = io.as_object()["nonblocking"];
+		BOOST_REQUIRE(nonblocking.is_object());
+		BOOST_REQUIRE_EQUAL(nonblocking.as_object()["current_size"].as_uint(), 0);
+	};
+
+	for (const auto &tuple : enabled_backends) {
+		check_backend(tuple, true);
+	}
+
+	for (const auto &tuple : disabled_backends) {
+		check_backend(tuple, false);
+	}
+
+	const auto &io = statistics.as_object()["io"];
+	BOOST_REQUIRE(io.is_object());
+
+	const auto &pools_stats = io.as_object()["pools"];
+	BOOST_REQUIRE(pools_stats.is_object());
+
+	auto pools = [&enabled_backends]() {
+		std::unordered_set<std::string> ret;
+		for (const auto &tuple : enabled_backends) {
+			const auto &pool_id = std::get<1>(tuple);
+			if (!pool_id.empty())
+				ret.emplace(pool_id);
+		}
+		return std::move(ret);
+	}();
+	BOOST_REQUIRE_EQUAL(pools_stats.as_object().size(), pools.size());
+
+	for (const auto &pool_id: pools) {
+		const auto &pool = pools_stats.as_object()[pool_id];
+		BOOST_REQUIRE(pool.is_object());
+		{
+			const auto &blocking = pool.as_object()["blocking"];
+			BOOST_REQUIRE(blocking.is_object());
+			BOOST_REQUIRE_EQUAL(blocking.as_object()["current_size"].as_uint(), 0);
+
+			const auto &nonblocking = pool.as_object()["nonblocking"];
+			BOOST_REQUIRE(nonblocking.is_object());
+			BOOST_REQUIRE_EQUAL(nonblocking.as_object()["current_size"].as_uint(), 0);
+		}
+	}
+}
+
+static void test_empy_node(ioremap::elliptics::newapi::session &s) {
+	check_statistics(s, {}, {});
+}
+
+static void add_backends_to_config(const nodes_data *setup,
+                                   std::vector<std::tuple<uint32_t, std::string>> backends_to_add) {
+	auto config_path = setup->nodes.front().config_path();
+
+	auto config = [&config_path]() {
+		// read and parse server config
+		std::ifstream stream(config_path);
+		return kora::dynamic::read_json(stream);
+	}();
+	auto &backends = config.as_object()["backends"];
+
+	BOOST_REQUIRE(backends.is_array());
+	BOOST_REQUIRE_EQUAL(backends.as_array().size(), 0);
+
+	for (const auto &backend_to_add : backends_to_add) {
+		const auto &backend_id = std::get<0>(backend_to_add);
+		const auto &pool_id = std::get<1>(backend_to_add);
+
+		// prepare directory for the backend
+		std::string prefix =
+		        config_path.substr(0, config_path.find_last_of('/')) + '/' + std::to_string(backend_id);
+		create_directory(prefix);
+		create_directory(prefix + "/history");
+		create_directory(prefix + "/blob");
+
+		// add backend with individual pool
+		kora::dynamic_t::object_t backend;
+		backend["type"] = "blob";
+		backend["backend_id"] = backend_id;
+		backend["history"] = prefix + "/history";
+		backend["data"] = prefix + "/blob";
+		backend["group"] = backend_to_group(backend_id);
+		if (!pool_id.empty())
+			backend["pool_id"] = pool_id;
+		backends.as_array().emplace_back(std::move(backend));
+	}
+
+	std::ofstream stream(config_path);
+	kora::write_pretty_json(stream, config);
+}
+
+static void test_one_backend(ioremap::elliptics::newapi::session &s,
+                             const nodes_data *setup,
+                             const std::tuple<uint32_t, std::string> &backend) {
+	// add backend with @backend_id and individual pool to config
+	add_backends_to_config(setup, {backend});
+	// nothing should happen after config update
+	check_statistics(s, {}, {});
+
+	// repeat test's body 20 times
+	// for (size_t i = 0; i < 20; ++i) {
+		// make enabled -> disable -> remove
+		enable_backend(s, setup, std::get<0>(backend));
+		check_statistics(s, {backend}, {});
+
+		disable_backend(s, setup, std::get<0>(backend));
+		check_statistics(s, {}, {backend});
+
+		remove_backend(s, setup, std::get<0>(backend));
+		check_statistics(s, {}, {});
+
+		// make enabled -> remove
+		enable_backend(s, setup, std::get<0>(backend));
+		check_statistics(s, {backend}, {});
+
+		remove_backend(s, setup, std::get<0>(backend));
+		check_statistics(s, {}, {});
+	// }
+
+	// revert on-disk config to original one
+	setup->nodes.front().config().write(setup->nodes.front().config_path());
+}
+
+typedef std::array<std::tuple<uint32_t, std::string>, 2> two_backends_array;
+
+static void test_two_backends(ioremap::elliptics::newapi::session &s,
+                              const nodes_data *setup,
+                              two_backends_array backends) {
+	// add backend with @backend_id and shared pool to config
+	add_backends_to_config(setup, {backends[0], backends[1]});
+	// nothing should happen after config update
+	check_statistics(s, {}, {});
+
+	// enable one by one backends
+
+	enable_backend(s, setup, std::get<0>(backends[0]));
+	check_statistics(s, {backends[0]}, {});
+
+	enable_backend(s, setup, std::get<0>(backends[1]));
+	check_statistics(s, {backends[0], backends[1]}, {});
+
+	// disable one by one backends
+
+	disable_backend(s, setup, std::get<0>(backends[0]));
+	check_statistics(s, {backends[1]}, {backends[0]});
+
+	disable_backend(s, setup, std::get<0>(backends[1]));
+	check_statistics(s, {}, {backends[0], backends[1]});
+
+	// remove one by one backends
+
+	remove_backend(s, setup, std::get<0>(backends[0]));
+	check_statistics(s, {}, {backends[1]});
+
+	remove_backend(s, setup, std::get<0>(backends[1]));
+	// after remove node should be returned to original state
+	check_statistics(s, {}, {});
+
+	// revert on-disk config to original one
+	setup->nodes.front().config().write(setup->nodes.front().config_path());
+}
+
+static void test_backends_with_delay(ioremap::elliptics::newapi::session &s, const nodes_data *setup) {
+	two_backends_array backends = {std::make_tuple(1, "pool"), std::make_tuple(2, "pool")};
+	const auto delayed_backend_id = std::get<0>(backends[0]);
+	const auto normal_backend_id = std::get<0>(backends[1]);
+
+	auto read_from_backend = [&](uint32_t backend_id) {
+		const int group = backend_to_group(backend_id);
+		auto read_session = s.clone();
+		read_session.set_groups({group});
+		read_session.set_timeout(1);
+		return read_session.read_data({"non-existent-key"}, 0, 0);
+	};
+
+	// add 2 backends with a shared pool to config
+	add_backends_to_config(setup, {backends[0], backends[1]});
+
+	// enable both backend
+	enable_backend(s, setup, std::get<0>(backends[0]));
+	enable_backend(s, setup, std::get<0>(backends[1]));
+
+	// check that both backends are enabled
+	check_statistics(s, {backends[0], backends[1]}, {});
+
+	// set 2 second delay to first backend
+	s.set_delay(setup->nodes.front().remote(), delayed_backend_id, 2000).wait();
+
+	{ // check delay
+		auto async = read_from_backend(delayed_backend_id);
+		async.wait();
+		BOOST_REQUIRE_EQUAL(async.error().code(), -ETIMEDOUT);
+	}
+
+	{ // asynchronously send command to both backends and check that second backend will not timeout
+		auto delayed_async = read_from_backend(delayed_backend_id);
+		auto normal_async = read_from_backend(normal_backend_id);
+		delayed_async.wait();
+		normal_async.wait();
+		BOOST_REQUIRE_EQUAL(delayed_async.error().code(), -ETIMEDOUT);
+		BOOST_REQUIRE_EQUAL(normal_async.error().code(), -ENOENT);
+	}
+
+	{ // asynchronously send bulk_read to delayed backend, remove it and check that removing waits bulk_read's
+	  // completion
+		auto read_session = s.clone();
+		read_session.set_timeout(1);
+		// generate ids for bulk read
+		auto ids = [&]() {
+			dnet_id id;
+			read_session.transform("non-existent-key", id);
+			id.group_id = backend_to_group(delayed_backend_id);
+			return std::vector<dnet_id>(1000, id); // use one key 1000 times
+		}();
+		auto delayed_async = read_session.bulk_read(ids);
+		remove_backend(s, setup, std::get<0>(backends[0]));
+		// remove_backend should wait bulk_read completion, so when it is completed
+		// bulk_read should also be completed.
+		BOOST_REQUIRE(delayed_async.ready());
+	}
+
+	// remove the remaining backend
+	remove_backend(s, setup, std::get<0>(backends[1]));
+	// check original state of statistics
+	check_statistics(s, {}, {});
+
+	// revert on-disk config to original one
+	setup->nodes.front().config().write(setup->nodes.front().config_path());
+}
+
+bool register_tests(const nodes_data *setup) {
+	auto n = setup->node->get_native();
+
+	// Test node without enabled backends after start-up
+	ELLIPTICS_TEST_CASE(test_empy_node, use_session(n));
+
+	// Test node with one backend
+
+	// one backend with individual pool
+	ELLIPTICS_TEST_CASE(test_one_backend, use_session(n), setup, std::make_tuple(1, ""));
+	// one backend with shared pool
+	ELLIPTICS_TEST_CASE(test_one_backend, use_session(n), setup, std::make_tuple(1, "bla"));
+
+	// Test node with two backends
+
+	// two backends with one shared pool
+	ELLIPTICS_TEST_CASE(test_two_backends, use_session(n), setup,
+	                    two_backends_array{std::make_tuple(1, "bla"), std::make_tuple(2, "bla")});
+	// two backends with two different shared pool
+	ELLIPTICS_TEST_CASE(test_two_backends, use_session(n), setup,
+	                    two_backends_array{std::make_tuple(1, "bla1"), std::make_tuple(2, "bla2")});
+	// one backend with shared pool and one with individual
+	ELLIPTICS_TEST_CASE(test_two_backends, use_session(n), setup,
+	                    two_backends_array{std::make_tuple(1, "bla1"), std::make_tuple(2, "")});
+
+	// test affecting backend's delay on other backends which share the same pool
+	ELLIPTICS_TEST_CASE(test_backends_with_delay, use_session(n), setup);
+
+	return true;
+}
+
+tests::nodes_data::ptr configure_test_setup_from_args(int argc, char *argv[]) {
+	namespace bpo = boost::program_options;
+
+	bpo::variables_map vm;
+	bpo::options_description generic("Test options");
+
+	std::string path;
+
+	generic.add_options()
+		("help", "This help message")
+		("path", bpo::value(&path), "Path where to store everything")
+		;
+
+	bpo::store(bpo::parse_command_line(argc, argv, generic), vm);
+	bpo::notify(vm);
+
+	if (vm.count("help")) {
+		std::cerr << generic;
+		return nullptr;
+	}
+
+	return configure_test_setup(path);
+}
+
+/*
+ * Common test initialization routine.
+ */
+using namespace tests;
+using namespace boost::unit_test;
+
+/*FIXME: forced to use global variable and plain function wrapper
+ * because of the way how init_test_main works in boost.test,
+ * introducing a global fixture would be a proper way to handle
+ * global test setup
+ */
+namespace {
+std::shared_ptr<nodes_data> setup;
+bool init_func() {
+	return register_tests(setup.get());
+}
+}
+
+int main(int argc, char *argv[]) {
+	srand(time(nullptr));
+
+	// we own our test setup
+	setup = configure_test_setup_from_args(argc, argv);
+
+	int result = unit_test_main(init_func, argc, argv);
+
+	// disassemble setup explicitly, to be sure about where its lifetime ends
+	setup.reset();
+
+	return result;
+}
+

--- a/tests/locks_test.cpp
+++ b/tests/locks_test.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "test_base.hpp"
-#include "../library/elliptics.h"
+#include "library/elliptics.h"
 #include <algorithm>
 
 #define BOOST_TEST_NO_MAIN

--- a/tests/reconnect_test.cpp
+++ b/tests/reconnect_test.cpp
@@ -15,7 +15,7 @@
 
 #include "test_base.hpp"
 #include "test_session.hpp"
-#include "../library/elliptics.h"
+#include "library/elliptics.h"
 
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API

--- a/tests/server_send.cpp
+++ b/tests/server_send.cpp
@@ -18,6 +18,8 @@
 #include "library/logger.hpp"
 #include <algorithm>
 
+#include <blackhole/attribute.hpp>
+
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API
 #include <boost/test/included/unit_test.hpp>

--- a/tests/stats_test.cpp
+++ b/tests/stats_test.cpp
@@ -14,8 +14,8 @@
  */
 
 #include "test_base.hpp"
-#include "../monitor/event_stats.hpp"
-#include "../monitor/monitor.hpp"
+#include "monitor/event_stats.hpp"
+#include "monitor/monitor.hpp"
 
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -1,7 +1,7 @@
 #define TEST_DO_NOT_INCLUDE_PLACEHOLDERS
 
 #include "test_base.hpp"
-#include "../example/common.h"
+#include "example/common.h"
 
 #include "library/logger.hpp"
 

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -318,7 +318,7 @@ struct json_value_visitor : public boost::static_visitor<>
 	}
 };
 
-void server_config::write(const std::string &path) {
+void server_config::write(const std::string &path) const {
 	rapidjson::MemoryPoolAllocator<> allocator;
 
 	rapidjson::Value sevmap;

--- a/tests/test_base.hpp
+++ b/tests/test_base.hpp
@@ -217,7 +217,7 @@ class server_config
 public:
 	static server_config default_value();
 
-	void write(const std::string &path);
+	void write(const std::string &path) const;
 	server_config &apply_options(const config_data &data);
 
 	config_data options;
@@ -287,6 +287,8 @@ private:
 	std::string m_path;
 	bool m_remove;
 };
+
+void create_directory(const std::string &path);
 
 struct nodes_data
 {

--- a/tests/weights_test.cpp
+++ b/tests/weights_test.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "test_base.hpp"
-#include "../library/elliptics.h"
+#include "library/elliptics.h"
 #include <algorithm>
 
 #define BOOST_TEST_NO_MAIN


### PR DESCRIPTION
Now several backends occording to their configs can share a io pool.
To make a backend use a shared io pool, its config should have 'pool_id'.

In addition, shared io pool can be configured by putting a section
into `options->pools->pool_id`. If io pool's config isn't specified,
io pool will be created with options taken from node.

Shared io pool is created when the first backend configured with it is enabled
and is destroyed when the last backend configured with it is disabled.

Also this PR includes code refactoring and cleanup.