### PR TITLE
python: pass remotes as is in elliptics.create_node

### DIFF
--- a/bindings/python/src/misc.py
+++ b/bindings/python/src/misc.py
@@ -80,7 +80,7 @@ def create_node(elog=None, log_file='/dev/stderr', log_level=log_level.error,
         cfg.net_thread_num = net_thread_num
     n = Node(elog, cfg)
     try:
-        n.add_remotes(map(Address.from_host_port_family, remotes))
+        n.add_remotes(remotes)
     except:
         pass
     return n


### PR DESCRIPTION
elliptics.Node.add_remotes converts different types of remotes by itself, so elliptics.create_node shouldn't do it.