### PR TITLE
Return -ENOENT if a backend is not found

### DIFF
--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -442,7 +442,7 @@ static int dnet_cmd_backend_control_dangerous(struct dnet_net_state *st, struct 
 	if (!backend) {
 		DNET_LOG_ERROR(node, "backend_control: there is no such backend: {}, state: {}", control->backend_id,
 		               dnet_state_dump_addr(st));
-		return -EINVAL;
+		return -ENOENT;
 	}
 
 	if (cmd->size != sizeof(dnet_backend_control) + control->ids_count * sizeof(dnet_raw_id)) {


### PR DESCRIPTION
For `DNET_CMD_BACKEND_CONTROL` packet reply with `-ENOENT` if specified backend is not found.
Previously it was `-EINVAL` and cause confusion with other errors.