### PR TITLE
elliptics_unique_lock refactoring and improvements

### DIFF
--- a/bindings/cpp/timer.hpp
+++ b/bindings/cpp/timer.hpp
@@ -31,8 +31,8 @@ private:
 	time_point time_point_;
 };
 
-typedef timer<std::chrono::system_clock> system_timer;
-typedef timer<std::chrono::steady_clock> steady_timer;
-typedef timer<std::chrono::high_resolution_clock> high_resolution_timer;
+using system_timer = timer<std::chrono::system_clock>;
+using steady_timer = timer<std::chrono::steady_clock>;
+using high_resolution_timer = timer<std::chrono::high_resolution_clock>;
 
 }}} /* namespace ioremap::elliptics::util */

--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -28,6 +28,7 @@
 #include "rapidjson/document.h"
 
 #include "example/config.hpp"
+#include "local_session.h"
 
 namespace ioremap { namespace cache {
 

--- a/cache/local_session.h
+++ b/cache/local_session.h
@@ -69,39 +69,4 @@ private:
 	uint64_t m_cflags;
 };
 
-class elliptics_timer {
-public:
-	typedef std::chrono::time_point<std::chrono::system_clock> time_point_t;
-
-	elliptics_timer()
-	{
-		m_last_time_chrono = std::chrono::system_clock::now();
-	}
-
-	template<class Period = std::chrono::milliseconds>
-	long long int elapsed() const
-	{
-		time_point_t time_chrono = std::chrono::system_clock::now();
-		return delta<Period>(m_last_time_chrono, time_chrono);
-	}
-
-	template<class Period = std::chrono::milliseconds>
-	long long int restart()
-	{
-		time_point_t time_chrono = std::chrono::system_clock::now();
-		std::swap(m_last_time_chrono, time_chrono);
-
-		return delta<Period>(time_chrono, m_last_time_chrono);
-	}
-
-private:
-	template<class Period>
-	long long int delta(const time_point_t& start, const time_point_t& end) const
-	{
-		return (std::chrono::duration_cast<Period> (end - start)).count();
-	}
-
-	time_point_t m_last_time_chrono;
-};
-
 #endif // LOCAL_SESSION_H


### PR DESCRIPTION
Remove elliptics_timer and use steady_timer instead.
lock(): separate time spent on locking the mutex and time spent in unlocked state, since the last is not so critical.