### PR TITLE
 recovery: extend and use extended server-send

### DIFF
--- a/bindings/python/elliptics_session.cpp
+++ b/bindings/python/elliptics_session.cpp
@@ -805,7 +805,9 @@ public:
 	}
 
 	python_iterator_result server_send(const bp::api::object &keys, uint64_t flags, uint64_t chunk_size,
-	                                   int src_group, const bp::api::object &dst_groups) {
+	                                   int src_group, const bp::api::object &dst_groups,
+	                                   uint64_t chunk_write_timeout,
+	                                   uint64_t chunk_commit_timeout) {
 		auto std_dst_groups = convert_to_vector<int>(dst_groups);
 		std::vector<dnet_raw_id> std_keys;
 		std_keys.reserve(bp::len(keys));
@@ -815,7 +817,8 @@ public:
 		}
 
 		return create_result(
-			newapi::session{*this}.server_send(std_keys, flags, chunk_size, src_group, std_dst_groups)
+			newapi::session{*this}.server_send(std_keys, flags, chunk_size, src_group, std_dst_groups,
+			                                   chunk_write_timeout, chunk_commit_timeout)
 		);
 	}
 
@@ -1959,7 +1962,10 @@ void init_elliptics_session() {
 		     "                       result.json))\n")
 
 		.def("server_send", &newapi::elliptics_session::server_send,
-		     bp::args("keys", "flags", "chunk_size", "src_group", "dst_groups"))
+		     (bp::arg("keys"), bp::arg("flags"), bp::arg("chunk_size"), bp::arg("src_group"),
+		      bp::arg("dst_groups"),
+		      bp::arg("chunk_write_timeout")=DNET_DEFAULT_SERVER_SEND_CHUNK_WRITE_TIMEOUT,
+		      bp::arg("chunk_commit_timeout")=DNET_DEFAULT_SERVER_SEND_CHUNK_COMMIT_TIMEOUT))
 
 		.def("bulk_read_json", &newapi::elliptics_session::bulk_read_json,
 		     (bp::arg("keys")),

--- a/example/eblob_backend.cpp
+++ b/example/eblob_backend.cpp
@@ -1187,19 +1187,19 @@ static iterator_callback make_iterator_server_send_callback(eblob_backend_config
 						   json, info->jhdr.capacity,
 						   data, info->data_size);
 
-			async.connect([=, &request, &monitor] (const newapi::sync_write_result &/*results*/, const error_info &error) {
-					if (st->__need_exit) {
-					        DNET_LOG_ERROR(
-					                c->blog,
-					                "EBLOB: Interrupting server_send: peer has been disconnected");
-				        } else {
-						auto response = serialize_response(error.code());
-						dnet_send_reply(st, cmd, response.data(), response.size(), 1,
-						                /*context*/ nullptr);
-					}
+			async.connect([=, &request, &monitor](const newapi::sync_write_result &/*results*/,
+			                                      const error_info &error) {
+				if (st->__need_exit) {
+					DNET_LOG_ERROR(c->blog,
+					               "EBLOB: Interrupting server_send: peer has been disconnected");
+				} else {
+					auto response = serialize_response(error.code());
+					dnet_send_reply(st, cmd, response.data(), response.size(), 1,
+					                /*context*/ nullptr);
+				}
 
-					monitor.remove_bytes(info->jhdr.size + info->data_size);
-				});
+				monitor.remove_bytes(info->jhdr.size + info->data_size);
+			});
 		} else {
 			uint64_t data_offset = 0;
 			data = data_pointer::allocate(request.chunk_size);
@@ -1225,8 +1225,8 @@ static iterator_callback make_iterator_server_send_callback(eblob_backend_config
 
 				if (data_offset == 0) {
 					auto async = session.write_prepare(info->key,
-									   json, info->jhdr.capacity,
-									   data, 0, info->data_size);
+					                                   json, info->jhdr.capacity,
+					                                   data, 0, info->data_size);
 					if ((err = get_write_result(async)) != 0) {
 						return send_fail_reply(err);
 					}
@@ -1242,7 +1242,7 @@ static iterator_callback make_iterator_server_send_callback(eblob_backend_config
 
 					data_pointer data_slice{data.slice(0, data_size)};
 					auto async = session.write_commit(info->key, "", data_slice, data_offset,
-									  info->data_size);
+					                                  info->data_size);
 					err = get_write_result(async);
 
 					auto response = serialize_response(err);

--- a/include/elliptics/core.h
+++ b/include/elliptics/core.h
@@ -86,6 +86,12 @@
 /* Default size of a chunk in server_send */
 #define DNET_DEFAULT_SERVER_SEND_CHUNK_SIZE	(10 * 1024 * 1024)
 
+/* Default timeout in ms for writing a chunk by server_send */
+#define DNET_DEFAULT_SERVER_SEND_CHUNK_WRITE_TIMEOUT	1000 // 1 second
+
+/* Default timeout in ms for committing a chunk by server_send */
+#define DNET_DEFAULT_SERVER_SEND_CHUNK_COMMIT_TIMEOUT	1000 // 1 second
+
 #define DNET_DEFAULT_SEND_LIMIT 1000
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/include/elliptics/newapi/session.hpp
+++ b/include/elliptics/newapi/session.hpp
@@ -126,6 +126,27 @@ public:
 	async_iterator_result server_send(const std::vector<key> &keys, uint64_t flags, uint64_t chunk_size,
 	                                  const int src_group, const std::vector<int> &dst_groups);
 
+
+	/*
+	 * Ask \a src_group to send \a keys to \a dst_groups
+	 * \a keys - keys that should be sent
+	 * \a flags - flags that describes how \a keys should be written
+	 * \a chunk_size - size of chunk by which each keys should be written
+	 * \a chunk_write_timeout - timeout in ms for one chunk write operation
+	 * \a chunk_commit_timeout - timeout in ms for committing one chunk of data
+	 */
+	async_iterator_result server_send(const std::vector<dnet_raw_id> &keys, uint64_t flags, uint64_t chunk_size,
+	                                  const int src_group, const std::vector<int> &dst_groups,
+	                                  uint64_t chunk_write_timeout, uint64_t chunk_commit_timeout);
+
+	async_iterator_result server_send(const std::vector<std::string> &keys, uint64_t flags, uint64_t chunk_size,
+	                                  const int src_group, const std::vector<int> &dst_groups,
+	                                  uint64_t chunk_write_timeout, uint64_t chunk_commit_timeout);
+
+	async_iterator_result server_send(const std::vector<key> &keys, uint64_t flags, uint64_t chunk_size,
+	                                  const int src_group, const std::vector<int> &dst_groups,
+	                                  uint64_t chunk_write_timeout, uint64_t chunk_commit_timeout);
+
 	/*
 	 * Family of bulk_read methods are used to read keys from multiple groups/backends efficiently by
 	 * sending exactly one request to a node instead of sending multiple requests per each group.

--- a/library/protocol.cpp
+++ b/library/protocol.cpp
@@ -415,6 +415,14 @@ inline ioremap::elliptics::dnet_server_send_request &operator >>(msgpack::object
 		v.chunk_size = DNET_DEFAULT_SERVER_SEND_CHUNK_SIZE;
 	}
 
+	if (o.via.array.size > 5) {
+		p[4].convert(&v.chunk_write_timeout);
+		p[5].convert(&v.chunk_commit_timeout);
+	} else {
+		v.chunk_write_timeout = DNET_DEFAULT_SERVER_SEND_CHUNK_WRITE_TIMEOUT;
+		v.chunk_commit_timeout = DNET_DEFAULT_SERVER_SEND_CHUNK_COMMIT_TIMEOUT;
+	}
+
 	return v;
 }
 
@@ -426,6 +434,8 @@ inline msgpack::packer<Stream> &operator <<(msgpack::packer<Stream> &o,
 	o.pack(v.groups);
 	o.pack(v.flags);
 	o.pack(v.chunk_size);
+	o.pack(v.chunk_write_timeout);
+	o.pack(v.chunk_commit_timeout);
 
 	return o;
 }

--- a/library/protocol.hpp
+++ b/library/protocol.hpp
@@ -136,6 +136,8 @@ struct dnet_server_send_request {
 	std::vector<int> groups;
 	uint64_t flags;
 	uint64_t chunk_size;
+	uint64_t chunk_write_timeout;
+	uint64_t chunk_commit_timeout;
 };
 
 template<typename T>

--- a/recovery/elliptics_recovery/dc_server_send.py
+++ b/recovery/elliptics_recovery/dc_server_send.py
@@ -255,8 +255,16 @@ class ServerSendRecovery(object):
                     self.stats.counter('server_send' if i == 0 else 'server_send_retry', 1)
                     if i > 0:
                         self.ctx.stats.counter('retry_recover_keys', len(timeouted_keys))
-                    log.info("Server-send: group_id: {0}, remote_groups: {1}, num_keys: {2}".format(group_id, remote_groups, len(newest_keys)))
-                    iterator = self.session.server_send(newest_keys, 0, self.ctx.chunk_size, group_id, remote_groups)
+                    log.info("Server-send: group_id: %s, remote_groups: %s, num_keys: %s", group_id, remote_groups,
+                             len(newest_keys))
+                    iterator = self.session.server_send(keys=newest_keys,
+                                                        flags=0,
+                                                        chunk_size=self.ctx.chunk_size,
+                                                        src_group=group_id,
+                                                        dst_groups=remote_groups,
+                                                        chunk_write_timeout=self.ctx.chunk_write_timeout,
+                                                        chunk_commit_timeout=self.ctx.chunk_commit_timeout,
+                                                        )
                     timeouted_keys, corrupted_keys = self._check_server_send_results(iterator, key_infos_map, group_id)
                     newest_keys = timeouted_keys
                     if corrupted_keys:

--- a/recovery/elliptics_recovery/recovery.py
+++ b/recovery/elliptics_recovery/recovery.py
@@ -274,6 +274,8 @@ def main(options, args):
                          .format(options.wait_timeout, repr(e), traceback.format_exc()))
 
     ctx.iteration_timeout = options.iteration_timeout
+    ctx.chunk_write_timeout = options.chunk_write_timeout
+    ctx.chunk_commit_timeout = options.chunk_commit_timeout
 
     try:
         ctx.prepare_timeout = Time.from_epoch(options.prepare_timeout)
@@ -426,4 +428,8 @@ def run(args=None):
                             '[default: %default] Mb'))
     parser.add_option("--iteration-timeout", action="store", type="int", dest="iteration_timeout", default=12*60*60,
                       help="Timeout for elliptics iterations [default: %default]")
+    parser.add_option('--chunk-write-timeout', action='store', type='int', dest='chunk_write_timeout', default=1000,
+                      help='Timeout in ms for writing a chunk by server-send [default: %default]')
+    parser.add_option('--chunk-commit-timeout', action='store', type='int', dest='chunk_commit_timeout', default=1000,
+                      help='Timeout in ms for committing a chunk by server-send [default: %default]')
     return main(*parser.parse_args(args))

--- a/tests/new_api_server_send_test.cpp
+++ b/tests/new_api_server_send_test.cpp
@@ -411,9 +411,13 @@ void test_chunked_server_send(const ioremap::elliptics::newapi::session &session
 		key_ids.push_back(k.id);
 	}
 
-	auto async = s.server_send(key_ids, 0 /*flags*/,
-				   chunk_size,
-				   src_group, dst_groups);
+	auto async = s.server_send(key_ids,
+	                           /*flags*/ 0,
+	                           chunk_size,
+	                           src_group,
+	                           dst_groups,
+	                           DNET_DEFAULT_SERVER_SEND_CHUNK_WRITE_TIMEOUT,
+	                           DNET_DEFAULT_SERVER_SEND_CHUNK_COMMIT_TIMEOUT);
 
 	size_t counter = 0;
 	for (const auto &result : async) {
@@ -460,8 +464,10 @@ void test_simple_server_send(const ioremap::elliptics::newapi::session &session/
 	// send the key via server_send from src_group to dst_groups
 	{
 		auto async = s.server_send(std::vector<std::string>{key}, 0 /*flags*/,
-					   DNET_DEFAULT_SERVER_SEND_CHUNK_SIZE,
-		                           constants::src_group, constants::dst_groups);
+		                           DNET_DEFAULT_SERVER_SEND_CHUNK_SIZE,
+		                           constants::src_group, constants::dst_groups,
+		                           DNET_DEFAULT_SERVER_SEND_CHUNK_WRITE_TIMEOUT,
+		                           DNET_DEFAULT_SERVER_SEND_CHUNK_COMMIT_TIMEOUT);
 
 		dnet_raw_id raw_key;
 		s.transform(key, raw_key);


### PR DESCRIPTION
Add new parameters:
- chunk_write_timeout - timeout in ms for one chunk write operation
- chunk_commit_timeout - tiemout in ms for committing one chunk of data

Both timeouts are specified in ms, but before using they will be converted to seconds with rounding up.