### PR TITLE
Inform client about dropped request

### DIFF
--- a/library/request_queue.cpp
+++ b/library/request_queue.cpp
@@ -2,6 +2,8 @@
 
 #include <blackhole/attribute.hpp>
 
+#include <cerrno>
+
 #include "murmurhash.h"
 #include "monitor/measure_points.h"
 #include "example/config.hpp"
@@ -103,6 +105,10 @@ dnet_io_req *dnet_request_queue::pop_request(dnet_work_io *wio, const char *thre
 
 	if (!expired)
 		return r;
+
+	// Note: this function is marked with `weak` attribute and is not defined in client bindings,
+	// so this code should not be executed from client side otherwise it will lead to segfault.
+	dnet_send_ack(st, cmd, -ETIMEDOUT, 0, nullptr);
 
 	FORMATTED(HANDY_COUNTER_INCREMENT, ("pool.%s.queue.dropped", thread_stat_id), 1);
 	{

--- a/tests/queue_timeout.cpp
+++ b/tests/queue_timeout.cpp
@@ -21,6 +21,8 @@
 
 #include <boost/program_options.hpp>
 
+#include "bindings/cpp/timer.hpp"
+
 using namespace ioremap::elliptics;
 using namespace boost::unit_test;
 
@@ -67,7 +69,7 @@ static nodes_data::ptr configure_test_setup(const std::string &path) {
 	return start_nodes(start_config);
 }
 
-/* The test validates doping request on server-side after 1 seconds by follow:
+/* The test validates dropping request on server-side after 1 seconds by follow:
  * * write test key
  * * set backend delay to 1,5 seconds to make the backend sleep 1,5 seconds before handling request
  * * sequentially sends 2 async read of written key commands with 5 seconds timeout:
@@ -124,19 +126,19 @@ static void test_queue_ack_timeout(session &s, const nodes_data *setup) {
 
 	// test key and data
 	std::string key = "queue timeout reply with timout test key";
-	std::string data = "queue timeout reply with timout test key";
 
 	const auto &node = setup->nodes.front();
 	// sets 2 seconds delay to the only backend on the only node
 	constexpr uint64_t delay_ms = 2000;
 	s.set_delay(node.remote(), backend_id, delay_ms).get();
 
-	// sets 10 seconds session timeout - it should fit at least 2 x backend delay because
-	// if the second command won't be dropped due to queue timeout its handling time
-	// should be around 4 seconds (2 x backend delay).
-	constexpr auto session_timeout = 10;
-	s.set_timeout(session_timeout);
-	dnet_time start; dnet_current_time(&start);
+	// Make sufficient large client session timeout (10 seconds) to test the situation when first request was processed
+	// with `delay_ms` delay and second was dropped with ack as it's waiting time exceeds queue_timeout (1 second),
+	// so client would be informed earlier, before session expiration. Client should be informed instanly after `delta_ms`,
+	// plus some neglectable small time.
+	s.set_timeout(10);
+	s.set_filter(ioremap::elliptics::filters::all_with_ack);
+	ioremap::elliptics::util::steady_timer timer;
 
 	// first lookup will delay after decoupling from queue for `delay_ms`.
 	auto async = s.lookup(key);
@@ -147,11 +149,12 @@ static void test_queue_ack_timeout(session &s, const nodes_data *setup) {
 	} {
 		// second lookup command should fail with timeout error due to drop from server queue request.
 		ELLIPTICS_REQUIRE_ERROR(res, std::move(async_timeouted), -ETIMEDOUT);
-		const auto delta_sec = res.end_time().tsec - start.tsec;
+		BOOST_REQUIRE(res.get().front().command()->flags & DNET_FLAGS_REPLY);
+
+		const auto delta_ms = timer.get_ms();
 		// Warning: all timings comparsion is a "danger zone", as execution time could depends on many factors.
-		constexpr auto expected_to_elapsed_sec = delay_ms / 1000;
-		BOOST_REQUIRE_GE(delta_sec, expected_to_elapsed_sec);
-		BOOST_REQUIRE_LT(delta_sec, session_timeout / 2);
+		BOOST_REQUIRE_GE(delta_ms, delay_ms);
+		BOOST_REQUIRE_LT(delta_ms, 2 * delay_ms);
 	}
 }
 
@@ -184,7 +187,7 @@ static void test_overridden_queue_timeout(session &s, const nodes_data *setup) {
 		// the second command shouldn't be dropped due to queue timeout and its handling time
 		// should be around 3 seconds (2 x backend delay).
 		s.set_timeout(5);
-		// first read command. It will hold the only io thread on 2,5 seconds backend delay.
+		// first read command. It will hold the only io thread on 1,5 seconds backend delay.
 		auto async = s.read_data(key, 0, 0);
 		// second read command. It will be in io queue while the only io thread will sleep on backend delay.
 		auto async2 = s.read_data(key, 0, 0);
@@ -229,6 +232,7 @@ static bool register_tests(const nodes_data *setup) {
 	auto n = setup->node->get_native();
 
 	ELLIPTICS_TEST_CASE(test_queue_timeout, use_session(n, { group }, 0, 0), setup);
+	ELLIPTICS_TEST_CASE(test_queue_ack_timeout, use_session(n, { group }, 0, 0), setup);
 	ELLIPTICS_TEST_CASE(test_overridden_queue_timeout,
 	                    use_session(n, {group_with_overridden_queue_timeout}, 0, 0),
 	                    setup);


### PR DESCRIPTION
subj.

**TODO:**
 - [x] tests on the way.
