### PR TITLE
 backends: handle backends_status request in nonblocking sys pool

### DIFF
--- a/bindings/cpp/session.cpp
+++ b/bindings/cpp/session.cpp
@@ -1894,7 +1894,7 @@ async_backend_status_result session::request_backends_status(const address &addr
 	trace_scope scope{*this};
 	transport_control control;
 	control.set_command(DNET_CMD_BACKEND_STATUS);
-	control.set_cflags(DNET_FLAGS_NEED_ACK | DNET_FLAGS_DIRECT);
+	control.set_cflags(DNET_FLAGS_NEED_ACK | DNET_FLAGS_DIRECT | DNET_FLAGS_NOLOCK);
 
 	session sess = clean_clone();
 	sess.set_direct_id(addr);

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -1182,7 +1182,7 @@ int dnet_backends_manager::init_all(bool parallel) {
 			sess.set_checker(checkers::no_check);
 			sess.set_exceptions_policy(session::no_exceptions);
 			sess.set_timeout(std::numeric_limits<unsigned>::max() / 2);
-			sess.set_cflags(sess.get_cflags() | DNET_FLAGS_NO_QUEUE_TIMEOUT | DNET_FLAGS_NOLOCK);
+			sess.set_cflags(sess.get_cflags() | DNET_FLAGS_NO_QUEUE_TIMEOUT);
 
 			std::vector<async_backend_control_result> results;
 			results.reserve(m_backends.size());


### PR DESCRIPTION
Also revert "backends: enable backend in nonblocking sys io pool", because it affects other commands handling while backends are started