### PR TITLE
recovery: fix stopping on empty bucket for server-send

### DIFF
--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -15,6 +15,7 @@
 # =============================================================================
 
 import logging
+import itertools
 from itertools import groupby
 from collections import defaultdict
 from ..utils.misc import elliptics_create_node, dump_key_data, KeyInfo, load_key_data
@@ -206,9 +207,11 @@ class MergedKeys(object):
         else:
             dump_key_data(key_data, merged_file)
 
-        if key_infos:
-            newest_key_group = key_infos[0].group_id
-            self.newest_key_stats[newest_key_group] += 1
+        if not key_infos:
+            return
+
+        for info in itertools.takewhile(key_infos[0].same_meta, key_infos):
+            self.newest_key_stats[info.group_id] += 1
 
 
 def merge_results(arg):

--- a/recovery/elliptics_recovery/types/dc.py
+++ b/recovery/elliptics_recovery/types/dc.py
@@ -14,21 +14,20 @@
 # GNU General Public License for more details.
 # =============================================================================
 
-import logging
-import itertools
-from itertools import groupby
-from collections import defaultdict
-from ..utils.misc import elliptics_create_node, dump_key_data, KeyInfo, load_key_data
-from ..range import IdRange
-from ..etime import Time
-from ..iterator import Iterator, MergeData, IteratorResult
-from ..dc_recovery import recover
-
-import os
 import errno
+import itertools
+import logging
+import os
 import traceback
+from collections import defaultdict
 
 import elliptics
+
+from ..dc_recovery import recover
+from ..etime import Time
+from ..iterator import Iterator, MergeData, IteratorResult
+from ..range import IdRange
+from ..utils.misc import elliptics_create_node, dump_key_data, KeyInfo, load_key_data
 
 log = logging.getLogger(__name__)
 
@@ -302,8 +301,8 @@ def process_uncommitted(ctx, results):
 
     for r in results:
         with open(r.filename, 'ab') as f:
-            for _, batch in groupby(enumerate(load_key_data(r.uncommitted_filename)),
-                                    key=lambda x: x[0] / ctx.batch_size):
+            for _, batch in itertools.groupby(enumerate(load_key_data(r.uncommitted_filename)),
+                                              key=lambda x: x[0] / ctx.batch_size):
                 batch = [item[1] for item in batch]
                 tasks = []
                 statuses = {}  # (key, group_id) -> status

--- a/recovery/elliptics_recovery/utils/misc.py
+++ b/recovery/elliptics_recovery/utils/misc.py
@@ -307,6 +307,15 @@ class KeyInfo(object):
             self.data_offset,
             self.blob_id)
 
+    def same_meta(self, other):
+        """Check whether @self and @other have the same meta
+        :arg other: other instance of KeyInfo
+        :type other: KeyInfo
+        :return: whether self and other have the same meta
+        :rtype: bool
+         """
+        return (self.timestamp, self.size, self.user_flags) == (other.timestamp, other.size, other.user_flags)
+
     @classmethod
     def load(cls, data):
         return cls(elliptics.Address(data[0][0], data[0][1], data[0][2]),


### PR DESCRIPTION
It is possible that all keys from the bucket are already recovered (from previous buckets), so it is empty, but other buckets could still have keys to recover and we shouldn't stop here.

TODO:

- [x] Tests (depends on https://github.com/interiorem/elliptics/pull/217)