### PR TITLE
LIFO for nonblocking requests queueing

### DIFF
--- a/example/config.cpp
+++ b/example/config.cpp
@@ -401,8 +401,12 @@ extern "C" int dnet_node_set_verbosity(struct dnet_node *node, enum dnet_log_lev
 }
 
 static io_pool_config parse_io_pool_config(const config_data &data, const kora::config_t &config) {
-	return {config.at("io_thread_num", data.cfg_state.io_thread_num),
-	        config.at("nonblocking_io_thread_num", data.cfg_state.nonblocking_io_thread_num)};
+	return {
+		config.at("io_thread_num", data.cfg_state.io_thread_num),
+		config.at("nonblocking_io_thread_num", data.cfg_state.nonblocking_io_thread_num),
+		config.at("lifo", false),
+		config.at<size_t>("queue_limit", 1000)
+	};
 }
 
 static uint64_t parse_queue_timeout(const config_data &data, const kora::config_t &config) {
@@ -511,7 +515,12 @@ std::shared_ptr<backend_config> config_data::get_backend_config(uint32_t backend
 }
 
 io_pool_config config_data::get_io_pool_config(const std::string &pool_id) {
-	const io_pool_config default_config = {cfg_state.io_thread_num, cfg_state.nonblocking_io_thread_num};
+	const io_pool_config default_config = {
+		cfg_state.io_thread_num,
+		cfg_state.nonblocking_io_thread_num,
+		/*lifo*/ false,
+		/*queue_limit*/ 1000
+	};
 
 	const auto &root = parse_config()->root();
 	if (!root.has("options"))

--- a/example/config.hpp
+++ b/example/config.hpp
@@ -88,6 +88,8 @@ private:
 struct io_pool_config {
 	int io_thread_num;
 	int nonblocking_io_thread_num;
+	bool lifo;
+	size_t queue_limit;
 };
 
 struct config_data;

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -58,7 +58,7 @@ static std::shared_ptr<struct dnet_io_pool> create_io_pool(struct dnet_node *nod
 	}
 
 	err = dnet_work_pool_alloc(&pool->recv_pool, node, config.io_thread_num, DNET_WORK_IO_MODE_BLOCKING,
-	                           pool_id.c_str(), dnet_io_process);
+	                           config.queue_limit, pool_id.c_str(), dnet_io_process);
 	if (err) {
 		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to allocate blocking pool: {} [{}]",
 		               pool_id, strerror(-err), err);
@@ -76,7 +76,8 @@ static std::shared_ptr<struct dnet_io_pool> create_io_pool(struct dnet_node *nod
 	}
 
 	err = dnet_work_pool_alloc(&pool->recv_pool_nb, node, config.nonblocking_io_thread_num,
-	                           DNET_WORK_IO_MODE_NONBLOCKING, pool_id.c_str(), dnet_io_process);
+	                           config.lifo ? DNET_WORK_IO_MODE_LIFO : DNET_WORK_IO_MODE_NONBLOCKING,
+	                           config.queue_limit, pool_id.c_str(), dnet_io_process);
 	if (err) {
 		DNET_LOG_ERROR(node, "create_io_pool(pool_id: {}): failed to allocate nonblocking pool: {} [{}]",
 		               pool_id, strerror(-err), err);

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -340,8 +340,7 @@ struct dnet_net_io {
 enum dnet_work_io_mode {
 	DNET_WORK_IO_MODE_BLOCKING = 0,
 	DNET_WORK_IO_MODE_NONBLOCKING,
-	DNET_WORK_IO_MODE_CONTROL,
-	DNET_WORK_IO_MODE_EXEC_BLOCKING,
+	DNET_WORK_IO_MODE_LIFO,
 };
 
 struct dnet_work_pool;
@@ -397,6 +396,7 @@ int dnet_work_pool_alloc(struct dnet_work_pool_place *place,
                          struct dnet_node *n,
                          int num,
                          int mode,
+                         size_t queue_limit,
                          const char *pool_id,
                          void *(*process)(void *));
 int dnet_work_pool_place_init(struct dnet_work_pool_place *pool);


### PR DESCRIPTION
Introduce new io_pool mode: DNET_WORK_IO_MODE_LIFO In this mode io_pool will use LIFO instead of FIFO order for internal queue.