### PR TITLE
fix: use lifo by default in all cases

### DIFF
--- a/example/config.cpp
+++ b/example/config.cpp
@@ -518,7 +518,7 @@ io_pool_config config_data::get_io_pool_config(const std::string &pool_id) {
 	const io_pool_config default_config = {
 		cfg_state.io_thread_num,
 		cfg_state.nonblocking_io_thread_num,
-		/*lifo*/ false,
+		/*lifo*/ true,
 		/*queue_limit*/ 1000
 	};
 


### PR DESCRIPTION
Additional case when lifo should be true by default.