### PR TITLE
Support protocol-independent cache read and write

### DIFF
--- a/cache/cache.cpp
+++ b/cache/cache.cpp
@@ -147,7 +147,7 @@ write_response_t cache_manager::write(dnet_net_state *st,
 }
 
 write_response_t cache_manager::n2_write(dnet_net_state *st,
-                                         ioremap::elliptics::n2::request_info *req_info,
+                                         n2_request_info *req_info,
                                          dnet_access_context *context) {
 	return m_caches[idx(req_info->request->cmd.id.id)]->n2_write(st, req_info, context);
 }
@@ -336,7 +336,7 @@ static int dnet_cmd_cache_io_write_new(struct cache_manager *cache,
 
 static int n2_cmd_cache_io_write_new(struct cache_manager *cache,
                                      struct dnet_net_state *st,
-                                     ioremap::elliptics::n2::request_info *req_info,
+                                     n2_request_info *req_info,
                                      struct dnet_cmd_stats *cmd_stats,
                                      dnet_access_context *context) {
 	using namespace ioremap::elliptics;
@@ -518,7 +518,7 @@ static int dnet_cmd_cache_io_read_new(struct cache_manager *cache,
 
 static int n2_cmd_cache_io_read_new(struct cache_manager *cache,
                                     struct dnet_net_state *st,
-                                    ioremap::elliptics::n2::request_info *req_info,
+                                    n2_request_info *req_info,
                                     struct dnet_cmd_stats *cmd_stats,
                                     dnet_access_context *context) {
 	using namespace ioremap::elliptics;

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -416,8 +416,7 @@ public:
 	                       dnet_access_context *context);
 
 	write_response_t n2_write(dnet_net_state *st,
-	                          ioremap::elliptics::n2::call *call,
-	                          ioremap::elliptics::n2::write_request *request,
+	                          ioremap::elliptics::n2::request_info *req_info,
 	                          dnet_access_context *context);
 
 	read_response_t read(const unsigned char *id, uint64_t ioflags);

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -416,7 +416,7 @@ public:
 	                       dnet_access_context *context);
 
 	write_response_t n2_write(dnet_net_state *st,
-	                          ioremap::elliptics::n2::request_info *req_info,
+	                          n2_request_info *req_info,
 	                          dnet_access_context *context);
 
 	read_response_t read(const unsigned char *id, uint64_t ioflags);

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -27,6 +27,7 @@
 #include <boost/intrusive/list.hpp>
 
 #include "library/logger.hpp"  //TODO: remove from header file, required only by elliptics_unique_lock
+#include "library/n2_protocol.hpp"
 
 #include "bindings/cpp/timer.hpp"
 
@@ -413,6 +414,11 @@ public:
 	                       dnet_cmd *cmd,
 	                       const write_request &request,
 	                       dnet_access_context *context);
+
+	write_response_t n2_write(dnet_net_state *st,
+	                          ioremap::elliptics::n2::call *call,
+	                          ioremap::elliptics::n2::write_request *request,
+	                          dnet_access_context *context);
 
 	read_response_t read(const unsigned char *id, uint64_t ioflags);
 

--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -248,7 +248,7 @@ write_response_t slru_cache_t::write(dnet_net_state *st,
 }
 
 write_response_t slru_cache_t::n2_write(dnet_net_state *st,
-                                        ioremap::elliptics::n2::request_info *req_info,
+                                        n2_request_info *req_info,
                                         dnet_access_context *context) {
 	TIMER_SCOPE("write");
 
@@ -286,7 +286,7 @@ write_response_t slru_cache_t::n2_write(dnet_net_state *st,
 		const auto &callbacks = m_backend.callbacks();
 		int err = callbacks.n2_command_handler(st,
 		                                       callbacks.command_private,
-		                                       static_cast<n2_request_info *>(req_info),
+		                                       req_info,
 		                                       &stats,
 		                                       context);
 

--- a/cache/slru_cache.cpp
+++ b/cache/slru_cache.cpp
@@ -248,11 +248,11 @@ write_response_t slru_cache_t::write(dnet_net_state *st,
 }
 
 write_response_t slru_cache_t::n2_write(dnet_net_state *st,
-                                        ioremap::elliptics::n2::call *call,
-                                        ioremap::elliptics::n2::write_request *request,
+                                        ioremap::elliptics::n2::request_info *req_info,
                                         dnet_access_context *context) {
 	TIMER_SCOPE("write");
 
+	auto request = static_cast<ioremap::elliptics::n2::write_request *>(req_info->request.get());
 	auto &cmd = request->cmd;
 
 	const auto id = cmd.id.id;
@@ -286,8 +286,7 @@ write_response_t slru_cache_t::n2_write(dnet_net_state *st,
 		const auto &callbacks = m_backend.callbacks();
 		int err = callbacks.n2_command_handler(st,
 		                                       callbacks.command_private,
-		                                       static_cast<n2_call *>(call),
-		                                       request,
+		                                       static_cast<n2_request_info *>(req_info),
 		                                       &stats,
 		                                       context);
 

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -40,6 +40,11 @@ public:
 	                       const write_request &request,
 	                       dnet_access_context *context);
 
+	write_response_t n2_write(dnet_net_state *st,
+	                          ioremap::elliptics::n2::call *call,
+	                          ioremap::elliptics::n2::write_request *request,
+	                          dnet_access_context *context);
+
 	read_response_t read(const unsigned char *id, uint64_t ioflags);
 
 	int remove(const dnet_cmd *cmd, ioremap::elliptics::dnet_remove_request &request, dnet_access_context *context);
@@ -81,6 +86,8 @@ private:
 	}
 
 	int check_cas(const data_t* it, const dnet_cmd *cmd, const write_request &request) const;
+
+	int n2_check_cas(const data_t *it, const ioremap::elliptics::n2::write_request *request) const;
 
 	void sync_if_required(data_t* it, elliptics_unique_lock<std::mutex> &guard);
 

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -41,7 +41,7 @@ public:
 	                       dnet_access_context *context);
 
 	write_response_t n2_write(dnet_net_state *st,
-	                          ioremap::elliptics::n2::request_info *req_info,
+	                          n2_request_info *req_info,
 	                          dnet_access_context *context);
 
 	read_response_t read(const unsigned char *id, uint64_t ioflags);

--- a/cache/slru_cache.hpp
+++ b/cache/slru_cache.hpp
@@ -41,8 +41,7 @@ public:
 	                       dnet_access_context *context);
 
 	write_response_t n2_write(dnet_net_state *st,
-	                          ioremap::elliptics::n2::call *call,
-	                          ioremap::elliptics::n2::write_request *request,
+	                          ioremap::elliptics::n2::request_info *req_info,
 	                          dnet_access_context *context);
 
 	read_response_t read(const unsigned char *id, uint64_t ioflags);

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -39,7 +39,6 @@
 #include <unistd.h>
 
 #include <eblob/blob.h>
-#include <library/access_context.h>
 
 #include "elliptics/packet.h"
 #include "elliptics/interface.h"
@@ -51,8 +50,10 @@
 
 #include "example/eblob_backend.h"
 
+#include "library/access_context.h"
 #include "library/elliptics.h"
 #include "library/logger.hpp"
+#include "library/n2_protocol.h"
 
 /*
  * FIXME: __unused is used internally by glibc, so it may cause conflicts.
@@ -1273,6 +1274,16 @@ static int eblob_backend_command_handler(void *state,
 	return err;
 }
 
+static int n2_eblob_backend_command_handler(void *state,
+                                            void *priv,
+                                            struct n2_call *call_data,
+                                            struct n2_message *msg,
+                                            void *cmd_stats,
+                                            struct dnet_access_context *context) {
+	// TODO(sabramkin)
+	return -ENOTSUP;
+}
+
 static int dnet_blob_set_sync(struct dnet_config_backend *b,
                               const char *key __unused, const char *value)
 {
@@ -1613,6 +1624,7 @@ static int dnet_blob_config_init(struct dnet_config_backend *b, enum dnet_log_le
 
 	b->cb.command_private = c;
 	b->cb.command_handler = eblob_backend_command_handler;
+	b->cb.n2_command_handler = n2_eblob_backend_command_handler;
 	b->cb.backend_cleanup = eblob_backend_cleanup;
 	b->cb.checksum = eblob_backend_checksum;
 	b->cb.lookup = eblob_backend_lookup;

--- a/example/eblob_backend.c
+++ b/example/eblob_backend.c
@@ -1276,8 +1276,7 @@ static int eblob_backend_command_handler(void *state,
 
 static int n2_eblob_backend_command_handler(void *state,
                                             void *priv,
-                                            struct n2_call *call_data,
-                                            struct n2_message *msg,
+                                            struct n2_request_info *req_info,
                                             void *cmd_stats,
                                             struct dnet_access_context *context) {
 	// TODO(sabramkin)

--- a/example/eblob_backend.cpp
+++ b/example/eblob_backend.cpp
@@ -108,7 +108,7 @@ int blob_read_and_check_stamp(const eblob_backend_config *c,
 	return err;
 }
 
-static int dnet_get_filename(int fd, std::string &filename) {
+int dnet_get_filename(int fd, std::string &filename) {
 	char *name = nullptr;
 	if (const int err = dnet_fd_readlink(fd, &name) < 0)
 		return err;
@@ -185,9 +185,9 @@ int dnet_read_json_header(int fd, uint64_t offset, uint64_t size, dnet_json_head
 	return 0;
 }
 
-static int blob_read_and_check_flags_new(const eblob_backend_config *c,
-                                         eblob_key *key,
-                                         eblob_write_control *wc) {
+int blob_read_and_check_flags_new(const eblob_backend_config *c,
+                                  eblob_key *key,
+                                  eblob_write_control *wc) {
 	int err = eblob_read_return(c->eblob, key, EBLOB_READ_NOCSUM, wc);
 	if (err == 0 && wc->flags & BLOB_DISK_CTL_CORRUPTED) {
 		err = -EILSEQ;

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -55,6 +55,8 @@ struct dnet_net_state;
 struct dnet_config_data;
 struct dnet_node;
 struct dnet_session;
+struct n2_call;
+struct n2_message;
 
 int dnet_need_exit(struct dnet_node *n);
 void dnet_set_need_exit(struct dnet_node *n);
@@ -306,6 +308,14 @@ struct dnet_backend_callbacks {
 	char *			(* dir)(void);
 
 	int			(* lookup)(struct dnet_node *n, void *priv, struct dnet_io_local *io);
+
+	/* command handler processes DNET_CMD_* commands protocol-undependently */
+	int			(* n2_command_handler)(void *state,
+	                                               void *priv,
+	                                               struct n2_call *call_data,
+	                                               struct n2_message *msg,
+	                                               void *cmd_stats,
+	                                               struct dnet_access_context *context);
 };
 
 /*
@@ -905,6 +915,16 @@ int dnet_send_reply_threshold(void *state, struct dnet_cmd *cmd,
 
 int dnet_send_fd_threshold(struct dnet_net_state *st, void *header, uint64_t hsize,
                            int fd, uint64_t offset, uint64_t dsize);
+
+int n2_send_response(struct dnet_net_state *st,
+                     struct n2_call *call_data,
+                     struct n2_message *msg,
+                     struct dnet_access_context *context);
+
+int n2_send_error(struct dnet_net_state *st,
+                  struct n2_call *call_data,
+                  int errc,
+                  struct dnet_access_context *context);
 
 struct dnet_route_entry
 {

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -55,8 +55,8 @@ struct dnet_net_state;
 struct dnet_config_data;
 struct dnet_node;
 struct dnet_session;
-struct n2_call;
-struct n2_message;
+struct n2_request_info;
+struct n2_response_info;
 
 int dnet_need_exit(struct dnet_node *n);
 void dnet_set_need_exit(struct dnet_node *n);
@@ -312,8 +312,7 @@ struct dnet_backend_callbacks {
 	/* command handler processes DNET_CMD_* commands protocol-undependently */
 	int			(* n2_command_handler)(void *state,
 	                                               void *priv,
-	                                               struct n2_call *call_data,
-	                                               struct n2_message *msg,
+	                                               struct n2_request_info *req_info,
 	                                               void *cmd_stats,
 	                                               struct dnet_access_context *context);
 };
@@ -917,14 +916,13 @@ int dnet_send_fd_threshold(struct dnet_net_state *st, void *header, uint64_t hsi
                            int fd, uint64_t offset, uint64_t dsize);
 
 int n2_send_response(struct dnet_net_state *st,
-                     struct n2_call *call_data,
-                     struct n2_message *msg,
+                     struct n2_response_info *resp_info,
                      struct dnet_access_context *context);
 
-int n2_send_error(struct dnet_net_state *st,
-                  struct n2_call *call_data,
-                  int errc,
-                  struct dnet_access_context *context);
+int n2_send_error_response(struct dnet_net_state *st,
+                           struct n2_request_info *req_info,
+                           int errc,
+                           struct dnet_access_context *context);
 
 struct dnet_route_entry
 {

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -1537,10 +1537,9 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
 
 int n2_backend_process_cmd_raw(struct dnet_backend *backend,
                                struct dnet_net_state *st,
-                               struct n2_call *call_data,
-                               struct n2_message *msg,
+                               struct n2_request_info *req_info,
                                struct dnet_cmd_stats *cmd_stats,
                                struct dnet_access_context *context) {
 	auto &callbacks = backend->callbacks();
-	return callbacks.n2_command_handler(st, callbacks.command_private, call_data, msg, cmd_stats, context);
+	return callbacks.n2_command_handler(st, callbacks.command_private, req_info, cmd_stats, context);
 }

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -1534,3 +1534,13 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
 	auto &callbacks = backend->callbacks();
 	return callbacks.command_handler(st, callbacks.command_private, cmd, data, cmd_stats, context);
 }
+
+int n2_backend_process_cmd_raw(struct dnet_backend *backend,
+                               struct dnet_net_state *st,
+                               struct n2_call *call_data,
+                               struct n2_message *msg,
+                               struct dnet_cmd_stats *cmd_stats,
+                               struct dnet_access_context *context) {
+	auto &callbacks = backend->callbacks();
+	return callbacks.n2_command_handler(st, callbacks.command_private, call_data, msg, cmd_stats, context);
+}

--- a/library/backend.h
+++ b/library/backend.h
@@ -225,8 +225,7 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
 
 int n2_backend_process_cmd_raw(struct dnet_backend *backend,
                                struct dnet_net_state *st,
-                               struct n2_call *call_data,
-                               struct n2_message *msg,
+                               struct n2_request_info *req_info,
                                struct dnet_cmd_stats *cmd_stats,
                                struct dnet_access_context *context);
 
@@ -240,8 +239,7 @@ int dnet_cmd_cache_io(struct dnet_backend *backend,
 
 int n2_cmd_cache_io(struct dnet_backend *backend,
                     struct dnet_net_state *st,
-                    struct n2_call *call_data,
-                    struct n2_message *msg,
+                    struct n2_request_info *req_info,
                     struct dnet_cmd_stats *cmd_stats,
                     struct dnet_access_context *context);
 

--- a/library/backend.h
+++ b/library/backend.h
@@ -223,6 +223,13 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
                                  struct dnet_cmd_stats *cmd_stats,
                                  struct dnet_access_context *context);
 
+int n2_backend_process_cmd_raw(struct dnet_backend *backend,
+                               struct dnet_net_state *st,
+                               struct n2_call *call_data,
+                               struct n2_message *msg,
+                               struct dnet_cmd_stats *cmd_stats,
+                               struct dnet_access_context *context);
+
 // handle command by @backend's cache
 int dnet_cmd_cache_io(struct dnet_backend *backend,
                       struct dnet_net_state *st,
@@ -230,6 +237,13 @@ int dnet_cmd_cache_io(struct dnet_backend *backend,
                       char *data,
                       struct dnet_cmd_stats *cmd_stats,
                       struct dnet_access_context *context);
+
+int n2_cmd_cache_io(struct dnet_backend *backend,
+                    struct dnet_net_state *st,
+                    struct n2_call *call_data,
+                    struct n2_message *msg,
+                    struct dnet_cmd_stats *cmd_stats,
+                    struct dnet_access_context *context);
 
 // initialize backends' subsystem, but do not enable any backend
 int dnet_backends_init(struct dnet_node *node);

--- a/library/common.cpp
+++ b/library/common.cpp
@@ -28,3 +28,7 @@ struct dnet_work_pool_place *dnet_backend_get_place(struct dnet_node *node, ssiz
 	pthread_mutex_lock(&place->lock);
 	return place;
 }
+
+std::string describe_errc(int errc) {
+	return std::string(strerror(-errc)) + " (" + std::to_string(errc) + ")";
+}

--- a/library/common.hpp
+++ b/library/common.hpp
@@ -59,28 +59,6 @@ inline static int safe_call(Class *obj, Method method, Args &&...args)
 	}
 }
 
-template <typename LoggerRef>
-inline static void c_exception_guard_log(const LoggerRef &logger_ref, const char *func_name,
-                                         const char *exception_details) {
-	DNET_LOG_ERROR(logger_ref, "{}: {}", func_name, exception_details);
-}
-
-template <typename Callable, typename LoggerRef>
-inline static int c_exception_guard(Callable &&callable, const LoggerRef &logger_ref, const char *func_name) {
-	try {
-		return std::forward<Callable>(callable)();
-	} catch (std::bad_alloc &e) {
-		c_exception_guard_log(logger_ref, func_name, e.what());
-		return -ENOMEM;
-	} catch (std::exception &e) {
-		c_exception_guard_log(logger_ref, func_name, e.what());
-		return -EINVAL;
-	} catch (...) {
-		c_exception_guard_log(logger_ref, func_name, "non-standard exception");
-		return -EINVAL;
-	}
-}
-
 inline static bool operator <(const dnet_id &lhs, const dnet_id &rhs) {
 	return dnet_id_cmp(&lhs, &rhs) < 0;
 }

--- a/library/common.hpp
+++ b/library/common.hpp
@@ -3,6 +3,7 @@
 
 #include <mutex>
 #include "elliptics/interface.h"
+#include "library/logger.hpp"
 
 class dnet_pthread_mutex
 {
@@ -58,6 +59,28 @@ inline static int safe_call(Class *obj, Method method, Args &&...args)
 	}
 }
 
+template <typename LoggerRef>
+inline static void c_exception_guard_log(const LoggerRef &logger_ref, const char *func_name,
+                                         const char *exception_details) {
+	DNET_LOG_ERROR(logger_ref, "{}: {}", func_name, exception_details);
+}
+
+template <typename Callable, typename LoggerRef>
+inline static int c_exception_guard(Callable &&callable, const LoggerRef &logger_ref, const char *func_name) {
+	try {
+		return std::forward<Callable>(callable)();
+	} catch (std::bad_alloc &e) {
+		c_exception_guard_log(logger_ref, func_name, e.what());
+		return -ENOMEM;
+	} catch (std::exception &e) {
+		c_exception_guard_log(logger_ref, func_name, e.what());
+		return -EINVAL;
+	} catch (...) {
+		c_exception_guard_log(logger_ref, func_name, "non-standard exception");
+		return -EINVAL;
+	}
+}
+
 inline static bool operator <(const dnet_id &lhs, const dnet_id &rhs) {
 	return dnet_id_cmp(&lhs, &rhs) < 0;
 }
@@ -89,5 +112,7 @@ inline static bool operator <(const dnet_addr &lhs, const dnet_addr &rhs) {
 inline static  bool operator ==(const dnet_addr &first, const dnet_addr &second) {
 	return dnet_addr_equal(&first, &second);
 }
+
+std::string describe_errc(int errc);
 
 #endif // IOREMAP_ELLIPTICS_COMMON_HPP

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -1842,8 +1842,7 @@ int n2_process_cmd_raw(struct dnet_net_state *st,
                        struct dnet_access_context *context) {
 	int err = 0;
 	struct dnet_node *n = st->n;
-	struct n2_message *msg;
-	struct dnet_cmd *cmd = n2_request_info_access_cmd(msg);
+	struct dnet_cmd *cmd = n2_request_info_access_cmd(req_info);
 	const unsigned long long tid = cmd->trans;
 	struct timespec start, end;
 	struct dnet_cmd_stats cmd_stats;

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -64,7 +64,6 @@ struct dnet_io_req {
 	struct list_head		req_entry;
 
 	struct dnet_net_state		*st;
-	struct n2_message		*n2_msg;
 
 	// TODO: remove deprecated fields after refactoring complete
 	void				*header; /*Deprecated*/
@@ -83,6 +82,8 @@ struct dnet_io_req {
 	uint64_t			recv_time;
 
 	struct dnet_access_context 	*context;
+
+	struct n2_call			*call_data;
 };
 
 #define ELLIPTICS_PROTOCOL_VERSION_0 2
@@ -655,6 +656,11 @@ int __attribute__((weak)) dnet_process_cmd_raw(struct dnet_net_state *st,
                                                int recursive,
                                                long queue_time,
                                                struct dnet_access_context *context);
+int __attribute__((weak)) n2_process_cmd_raw(struct dnet_net_state *st,
+                                             struct n2_call *call_data,
+                                             int recursive,
+                                             long queue_time,
+                                             struct dnet_access_context *context);
 int dnet_process_recv(struct dnet_net_state *st, struct dnet_io_req *r);
 void dnet_trans_update_timestamp(struct dnet_trans *t);
 

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -60,6 +60,12 @@ struct dnet_cmd_stats;
 struct dnet_access_context;
 struct n2_message;
 
+enum dnet_io_req_type {
+	DNET_IO_REQ_OLD_PROTOCOL = 0,
+	DNET_IO_REQ_TYPED_REQUEST = 1,
+	DNET_IO_REQ_TYPED_RESPONSE = 2,
+};
+
 struct dnet_io_req {
 	struct list_head		req_entry;
 
@@ -83,7 +89,10 @@ struct dnet_io_req {
 
 	struct dnet_access_context 	*context;
 
-	struct n2_call			*call_data;
+	enum dnet_io_req_type		io_req_type;
+	struct n2_request_info		*request_info;
+	struct n2_response_info		*response_info;
+
 };
 
 #define ELLIPTICS_PROTOCOL_VERSION_0 2
@@ -657,7 +666,7 @@ int __attribute__((weak)) dnet_process_cmd_raw(struct dnet_net_state *st,
                                                long queue_time,
                                                struct dnet_access_context *context);
 int __attribute__((weak)) n2_process_cmd_raw(struct dnet_net_state *st,
-                                             struct n2_call *call_data,
+                                             struct n2_request_info *req_info,
                                              int recursive,
                                              long queue_time,
                                              struct dnet_access_context *context);

--- a/library/n2_protocol.cpp
+++ b/library/n2_protocol.cpp
@@ -57,8 +57,8 @@ data_place data_place::from_memory(data_pointer memory_data) {
 
 int send_response(struct dnet_net_state *st, struct dnet_cmd *cmd, std::function<void ()> response,
                   struct dnet_access_context *context) {
-	auto resp_info = new response_info({ *cmd, std::move(response) });
-	return n2_send_response(st, static_cast<n2_response_info *>(resp_info), context);
+	auto resp_info = new n2_response_info({ *cmd, std::move(response) });
+	return n2_send_response(st, resp_info, context);
 }
 
 }}} // namespace ioremap::elliptics::n2

--- a/library/n2_protocol.cpp
+++ b/library/n2_protocol.cpp
@@ -1,36 +1,86 @@
 #include "n2_protocol.h"
 #include "n2_protocol.hpp"
 
+#include <blackhole/attribute.hpp>
+#include <fcntl.h>
+
+#include "access_context.h"
+#include "common.hpp"
+#include "elliptics.h"
+
 namespace ioremap { namespace elliptics { namespace n2 {
+
+void data_in_file::detach() {
+	if (fd < 0)
+		return;
+
+	if ((on_exit & DNET_IO_REQ_FLAGS_CACHE_FORGET) && fsize)
+		posix_fadvise(fd, local_offset, fsize, POSIX_FADV_DONTNEED);
+	fd = -1;
+}
+
+data_pointer data_in_file::read_and_detach() {
+	auto data = data_pointer::allocate(fsize);
+
+	int err = dnet_read_ll(fd, data.data<char>(), fsize, local_offset);
+	if (err) {
+		throw std::runtime_error("Error while reading data: " + describe_errc(err));
+	}
+
+	detach();
+	return data;
+}
 
 data_place::place_type data_place::where() const {
 	return in_file.fd >= 0 ? IN_FILE : IN_MEMORY;
 }
 
-data_place data_place::from_file(const data_in_file &in_file) {
+void data_place::force_memory() {
+	if (where() == IN_FILE) {
+		in_memory = in_file.read_and_detach();
+	}
+}
+
+data_place data_place::from_file(data_in_file file_data) {
 	return {
-		.in_file = in_file,
+		.in_file = std::move(file_data),
 		.in_memory = {},
 	};
 }
 
-data_place data_place::from_memory(const data_pointer &in_memory) {
+data_place data_place::from_memory(data_pointer memory_data) {
 	return {
 		.in_file = {},
-		.in_memory = in_memory,
+		.in_memory = std::move(memory_data),
 	};
+}
+
+int send_response(struct dnet_net_state *st, call *c, message *msg, struct dnet_access_context *context) {
+	return n2_send_response(st, static_cast<n2_call *>(c), static_cast<n2_message *>(msg), context);
+}
+
+void read_response::make_owning() {
+	data.force_memory();
 }
 
 }}} // namespace ioremap::elliptics::n2
 
 extern "C" {
 
-void n2_message_free(struct n2_message *n2_msg) {
-	delete n2_msg;
+struct dnet_cmd *n2_message_access_cmd(struct n2_message *msg) {
+	return &msg->cmd;
 }
 
-struct dnet_cmd *n2_access_cmd(struct n2_message *n2_msg) {
-	return &n2_msg->cmd;
+int n2_call_get_request(struct dnet_node *n, struct n2_call *call_data, struct n2_message **msg) {
+	auto impl = [&]{
+		*msg = static_cast<n2_message *>(call_data->get_request().release());
+		return 0;
+	};
+	return c_exception_guard(impl, n, __FUNCTION__);
+}
+
+void n2_call_free(struct n2_call *call_data) {
+	delete call_data;
 }
 
 } // extern "C"

--- a/library/n2_protocol.h
+++ b/library/n2_protocol.h
@@ -7,13 +7,15 @@ extern "C" {
 
 struct dnet_cmd;
 struct dnet_node;
-struct n2_call;
+struct n2_request_info;
+struct n2_response_info;
 struct n2_message;
 
-struct dnet_cmd *n2_message_access_cmd(struct n2_message *msg);
+struct dnet_cmd *n2_request_info_access_cmd(struct n2_request_info *req_info);
+struct dnet_cmd *n2_response_info_access_cmd(struct n2_response_info *resp_info);
 
-int n2_call_get_request(struct dnet_node *n, struct n2_call *call_data, struct n2_message **msg);
-void n2_call_free(struct n2_call *call_data);
+void n2_request_info_free(struct n2_request_info *req_info);
+void n2_response_info_free(struct n2_response_info *resp_info);
 
 #ifdef __cplusplus
 }

--- a/library/n2_protocol.h
+++ b/library/n2_protocol.h
@@ -6,10 +6,14 @@ extern "C" {
 #endif
 
 struct dnet_cmd;
+struct dnet_node;
+struct n2_call;
 struct n2_message;
 
-struct dnet_cmd *n2_access_cmd(struct n2_message *);
-void n2_message_free(struct n2_message *n2_msg);
+struct dnet_cmd *n2_message_access_cmd(struct n2_message *msg);
+
+int n2_call_get_request(struct dnet_node *n, struct n2_call *call_data, struct n2_message **msg);
+void n2_call_free(struct n2_call *call_data);
 
 #ifdef __cplusplus
 }

--- a/library/n2_protocol.hpp
+++ b/library/n2_protocol.hpp
@@ -6,7 +6,33 @@
 #include "elliptics/packet.h"
 #include "elliptics/utils.hpp"
 
+struct n2_message {
+	dnet_cmd cmd;
+
+	virtual ~n2_message() = default;
+};
+
+struct n2_request : public n2_message {
+	dnet_time deadline;
+};
+
+struct n2_request_info {
+	std::unique_ptr<n2_request> request;
+
+	// Ways to reply (list will be extended for streaming repliers)
+	std::function<void (std::shared_ptr<n2_message>)> reply;
+	std::function<void (int)> reply_error;
+};
+
+struct n2_response_info {
+	dnet_cmd cmd; // for log, for routing (in case of error-response we not always have message to extract cmd)
+	std::function<void ()> response_processor;
+};
+
 namespace ioremap { namespace elliptics { namespace n2 {
+
+int send_response(struct dnet_net_state *st, struct dnet_cmd *cmd, std::function<void ()> response,
+                  struct dnet_access_context *context);
 
 struct data_in_file {
 	int fd = -1;
@@ -34,48 +60,13 @@ struct data_place {
 	static data_place from_memory(data_pointer in_memory);
 };
 
-struct message {
-	dnet_cmd cmd;
-
-	virtual ~message() = default;
-};
-
-struct request_info {
-	std::unique_ptr<message> request;
-
-	// Ways to reply (list will be extended for streaming repliers)
-	std::function<void (std::shared_ptr<message>)> reply;
-	std::function<void (int)> reply_error;
-};
-
-struct response_info {
-	dnet_cmd cmd; // for log, for routing (in case of error-response we not always have message to extract cmd)
-	std::function<void ()> response_processor;
-};
-
-int send_response(struct dnet_net_state *st, struct dnet_cmd *cmd, std::function<void ()> response,
-                  struct dnet_access_context *context);
-
-}}} // namespace ioremap::elliptics::n2
-
-// All requests/responses must be inherited from n2_message;
-// common_request is visible from dnet_io_req. Since this struct
-// is visible from C code, it is declared out of namespace.
-struct n2_message : ioremap::elliptics::n2::message {};
-struct n2_request_info : public ioremap::elliptics::n2::request_info {};
-struct n2_response_info : public ioremap::elliptics::n2::response_info {};
-
-namespace ioremap { namespace elliptics { namespace n2 {
-
 // TODO(sabramkin): add constructors to *_request structs (since {}-initialization has broken)
 
-struct read_request : n2_message {
+struct read_request : n2_request {
 	uint64_t ioflags;
 	uint64_t read_flags;
 	uint64_t data_offset;
 	uint64_t data_size;
-
-	dnet_time deadline;
 };
 
 struct read_response : n2_message {
@@ -95,7 +86,7 @@ struct read_response : n2_message {
 	data_place data;
 };
 
-struct write_request : n2_message {
+struct write_request : n2_request {
 	uint64_t ioflags;
 	uint64_t user_flags;
 
@@ -112,8 +103,6 @@ struct write_request : n2_message {
 	data_pointer data;
 
 	uint64_t cache_lifetime;
-
-	dnet_time deadline;
 };
 
 struct lookup_response : n2_message {

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -38,12 +38,14 @@
 
 #include "bindings/cpp/timer.hpp"
 
+#include "access_context.h"
+#include "common.hpp"
 #include "elliptics.h"
 #include "elliptics/packet.h"
 #include "elliptics/interface.h"
-#include "common.hpp"
-#include "protocol.hpp"
 #include "logger.hpp"
+#include "n2_protocol.hpp"
+#include "protocol.hpp"
 
 
 enum dnet_socket_state {
@@ -1409,4 +1411,96 @@ int dnet_trans_forward(struct dnet_io_req *r, struct dnet_net_state *orig, struc
 	}
 
 	return dnet_trans_send(t, r);
+}
+
+dnet_io_req *n2_create_io_req(struct n2_call *call_data) {
+	// To be freed in C code: used C-style allocation
+	auto r = static_cast<dnet_io_req *>(calloc(1, sizeof(dnet_io_req)));
+	if (!r)
+		throw std::bad_alloc();
+
+	r->call_data = call_data;
+	return r;
+}
+
+void n2_schedule_io_req(struct dnet_net_state *st, struct dnet_io_req *r, struct dnet_access_context *context) {
+	r->context = dnet_access_context_get(context);
+
+	clock_gettime(CLOCK_MONOTONIC_RAW, &st->rcv_start_ts);
+	st->rcv_finish_ts = st->rcv_start_ts;
+
+	r->st = dnet_state_get(st);
+	dnet_schedule_io(st->n, r);
+}
+
+void n2_send_response_local(struct dnet_net_state *st, struct n2_call *call_data,
+                            struct n2_message *msg, struct dnet_access_context *context) {
+	DNET_LOG_DEBUG(st->n, "Sending response to local state"); // TODO: dump response info
+
+	auto r = n2_create_io_req(call_data);
+	msg->make_owning();
+	call_data->reply(std::unique_ptr<ioremap::elliptics::n2::message>(msg));
+	n2_schedule_io_req(st, r, context);
+}
+
+void n2_send_error_local(struct dnet_net_state *st, struct n2_call *call_data,
+                         int errc, struct dnet_access_context *context) {
+	DNET_LOG_DEBUG(st->n, "Sending error response to local state: %d", errc);
+
+	auto r = n2_create_io_req(call_data);
+	call_data->reply_error(errc);
+	n2_schedule_io_req(st, r, context);
+}
+
+int n2_send_response(struct dnet_net_state *st,
+                     struct n2_call *call_data,
+                     struct n2_message *msg,
+                     struct dnet_access_context *context) {
+	try {
+		dnet_cmd *cmd = &msg->cmd;
+		DNET_LOG(st->n, DNET_LOG_NOTICE, "%s: %s: reply trans: %lld -> %s (%p): cflags: %s",
+			 dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), (unsigned long long)cmd->trans,
+			 dnet_state_dump_addr(st), static_cast<void *>(st),
+			 dnet_flags_dump_cflags(cmd->flags));
+
+		if (st == st->n->st) {
+			/*
+			 * If destination is local node, call with reply are scheduled to the proper IO pool directly.
+			 * If msg hold fd instead of data it should be read here (see n2_io_req_local).
+			 */
+			n2_send_response_local(st, call_data, msg, context);
+		} else {
+			// If destination is remote node, just reply on call.
+			call_data->reply(std::unique_ptr<ioremap::elliptics::n2::message>(msg));
+		}
+	} catch (const std::exception &e) {
+		DNET_LOG_ERROR(st->n, "Sending response: %s", e.what());
+		// TODO(sabramkin): delete n2_call, n2_message ?
+	}
+
+	// TODO(sabramkin): always returns 0: fix
+	return 0;
+}
+
+int n2_send_error(struct dnet_net_state *st,
+                  struct n2_call *call_data,
+                  int errc,
+                  struct dnet_access_context *context) {
+	try {
+		// TODO(sabramkin): log. For log, get cmd from call_data some way
+
+		if (st == st->n->st) {
+			n2_send_error_local(st, call_data, errc, context);
+
+		} else {
+			call_data->reply_error(errc);
+		}
+
+	} catch (const std::exception &e) {
+		DNET_LOG_ERROR(st->n, "Sending error_response: %s", e.what());
+		// TODO(sabramkin): delete n2_call ?
+	}
+
+	// TODO(sabramkin): always returns 0: fix
+	return 0;
 }

--- a/library/protocol.cpp
+++ b/library/protocol.cpp
@@ -678,6 +678,15 @@ void validate_json(const std::string &json) {
 	}
 }
 
+data_pointer serialize(const dnet_json_header &value) {
+	return serialize<dnet_json_header>(value);
+}
+
+void deserialize(const data_pointer &data, dnet_json_header &value) {
+	size_t offset = 0;
+	deserialize<dnet_json_header>(data, value, offset);
+}
+
 #define DEFINE_HEADER(TYPE) \
 template data_pointer serialize<TYPE>(const TYPE &); \
 template void deserialize(const data_pointer &data, TYPE &value, size_t &offset);
@@ -699,5 +708,4 @@ DEFINE_HEADER(dnet_server_send_request);
 
 DEFINE_HEADER(dnet_bulk_read_request);
 
-DEFINE_HEADER(dnet_json_header);
 }} // namespace ioremap::elliptics

--- a/library/protocol.hpp
+++ b/library/protocol.hpp
@@ -4,23 +4,9 @@
 #include <elliptics/packet.h>
 #include <elliptics/utils.hpp>
 
+#include "library/protocol_common.hpp"
+
 namespace ioremap { namespace elliptics {
-
-#define DNET_READ_FLAGS_JSON (1<<0)
-#define DNET_READ_FLAGS_DATA (1<<1)
-
-static inline const char *dnet_dump_read_flags(uint64_t flags)
-{
-	static __thread char buffer[256];
-	static struct flag_info infos[] = {
-		{ DNET_READ_FLAGS_JSON, "json" },
-		{ DNET_READ_FLAGS_DATA, "data" },
-	};
-
-	dnet_flags_dump_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));
-
-	return buffer;
-}
 
 struct dnet_read_request {
 	uint64_t ioflags;

--- a/library/protocol_common.hpp
+++ b/library/protocol_common.hpp
@@ -1,0 +1,31 @@
+#ifndef ELLIPTICS_PROTOCOL_COMMON_HPP
+#define ELLIPTICS_PROTOCOL_COMMON_HPP
+
+#include <elliptics/packet.h>
+#include <elliptics/utils.hpp>
+
+namespace ioremap { namespace elliptics {
+
+#define DNET_READ_FLAGS_JSON (1<<0)
+#define DNET_READ_FLAGS_DATA (1<<1)
+
+static inline const char *dnet_dump_read_flags(uint64_t flags)
+{
+	static __thread char buffer[256];
+	static struct flag_info infos[] = {
+		{ DNET_READ_FLAGS_JSON, "json" },
+		{ DNET_READ_FLAGS_DATA, "data" },
+	};
+
+	dnet_flags_dump_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));
+
+	return buffer;
+};
+
+data_pointer serialize(const dnet_json_header &value);
+
+void deserialize(const data_pointer &data, dnet_json_header &value);
+
+}} // namespace ioremap::elliptics
+
+#endif // ELLIPTICS_PROTOCOL_COMMON_HPP


### PR DESCRIPTION
I suggest to review at first these files in this order:
* `library/elliptics.h` (changes in `dnet_io_req`)
* `library/n2_protocol.hpp` (details, what we place in `dnet_io_req`)
* `include/elliptics/interface.h` (see `dnet_backend_callbacks::n2_command_handler`)

These changes are basic. If you don't agree with any, let's discuss till result convention.