### PR TITLE
feature/protocol-independent-1

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -26,10 +26,15 @@ set(ELLIPTICS_CLIENT_SRCS
     ../../library/crypto.c
     ../../library/crypto/sha512.c
     ../../library/dnet_common.c
+    ../../library/n2_protocol.cpp
     ../../library/net.c
     ../../library/net.cpp
     ../../library/node.c
     ../../library/notify_common.c
+    ../../library/old_protocol/deserialize.cpp
+    ../../library/old_protocol/old_protocol.cpp
+    ../../library/old_protocol/serialize.cpp
+    ../../library/old_protocol/repliers.cpp
     ../../library/pool.c
     ../../library/request_queue.cpp
     ../../library/rbtree.c

--- a/example/eblob_backend.cpp
+++ b/example/eblob_backend.cpp
@@ -37,6 +37,7 @@
 #include "library/request_queue.h"
 #include "library/logger.hpp"
 #include "library/access_context.h"
+#include "library/n2_protocol.hpp"
 
 #include "monitor/measure_points.h"
 
@@ -215,8 +216,12 @@ static int blob_read_and_check_flags_new(const eblob_backend_config *c,
 	return err;
 }
 
-int blob_file_info_new(eblob_backend_config *c, void *state, dnet_cmd *cmd, struct dnet_access_context *context) {
+int blob_file_info_new(eblob_backend_config *c, void *state, struct n2_request_info *req_info,
+                       struct dnet_access_context *context) {
 	using namespace ioremap::elliptics;
+
+	auto request = static_cast<n2::lookup_request *>(req_info->request.get());
+	auto cmd = &request->cmd;
 
 	if (context) {
 		context->add({{"id", std::string(dnet_dump_id(&cmd->id))},
@@ -357,27 +362,28 @@ int blob_file_info_new(eblob_backend_config *c, void *state, dnet_cmd *cmd, stru
 		}
 	}
 
-	auto response = serialize(dnet_lookup_response{
-		wc.flags,
-		ehdr.flags,
-		std::move(filename),
+	std::unique_ptr<n2::lookup_response>
+		response(new(std::nothrow) n2::lookup_response(request->cmd,
+						               wc.flags, // record_flags
+						               ehdr.flags, // user_flags
+						               std::move(filename), // path
+						               jhdr.timestamp, // json_timestamp
+						               wc.data_offset + json_offset, // json_offset
+						               json_size, // json_size
+						               jhdr.capacity, // json_capacity
+						               std::move(json_checksum), // json_checksum
+						               ehdr.timestamp, // data_timestamp
+						               wc.data_offset + data_offset, // data_offset
+						               data_size, // data_size
+						               std::move(data_checksum))); // data_checksum
+	if (!response) {
+		return -ENOMEM;
+	}
 
-		jhdr.timestamp,
-		wc.data_offset + json_offset,
-		json_size,
-		jhdr.capacity,
-		std::move(json_checksum),
-
-		ehdr.timestamp,
-		wc.data_offset + data_offset,
-		data_size,
-		std::move(data_checksum),
-	});
-
-	err = dnet_send_reply(state, cmd, response.data(), response.size(), 0, context);
+	err = req_info->repliers.on_reply(std::move(response));
 	if (err) {
-		DNET_LOG_ERROR(c->blog, "{}: EBLOB: blob-file-info-new: dnet_send_reply: data: {:p}, size: {}: {} [{}]",
-		               dnet_dump_id(&cmd->id), response.data(), response.size(), strerror(-err), err);
+		DNET_LOG_ERROR(c->blog, "{}: EBLOB: blob-file-info-new: on_reply: {} [{}]",
+		               dnet_dump_id(&cmd->id), strerror(-err), err);
 		return err;
 	}
 
@@ -2295,4 +2301,28 @@ int blob_bulk_remove_new(struct eblob_backend_config *config,
 		dnet_send_reply(st, &cmd_copy, nullptr, 0, last_read ? 0 : 1, /*context*/ nullptr);
 	}
 	return 0;
+}
+
+int n2_eblob_backend_command_handler(void *state,
+                                     void *priv,
+                                     struct n2_request_info *req_info,
+                                     void *cmd_stats,
+                                     struct dnet_access_context *context) {
+	int err = 0;
+	const dnet_cmd &cmd = req_info->request->cmd;
+	auto c = static_cast<eblob_backend_config *>(priv);
+
+	FORMATTED(HANDY_TIMER_SCOPE, ("eblob_backend.cmd.%s", dnet_cmd_string(cmd.cmd)));
+
+	// TODO(shaitan): pass @cmd_stats to all blob_* functions and update statistics by them
+	switch (cmd.cmd) {
+		case DNET_CMD_LOOKUP_NEW:
+			err = blob_file_info_new(c, state, req_info, context);
+			break;
+		default:
+			err = -ENOTSUP;
+			break;
+	}
+
+	return err;
 }

--- a/example/eblob_backend.h
+++ b/example/eblob_backend.h
@@ -54,7 +54,7 @@ struct eblob_backend_config {
 
 int dnet_blob_config_to_json(struct dnet_config_backend *b, char **json_stat, size_t *size);
 
-int blob_file_info_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd,
+int blob_file_info_new(struct eblob_backend_config *c, void *state, struct n2_request_info *req_info,
                        struct dnet_access_context *context);
 int blob_del_new(struct eblob_backend_config *c, struct dnet_cmd *cmd, void *data, struct dnet_access_context *context);
 int blob_read_new(struct eblob_backend_config *c, void *state, struct dnet_cmd *cmd, void *data,
@@ -82,6 +82,12 @@ int blob_bulk_remove_new(struct eblob_backend_config *c,
                          struct dnet_cmd *cmd,
                          void *data,
                          struct dnet_access_context *context);
+
+int n2_eblob_backend_command_handler(void *state,
+                                     void *priv,
+                                     struct n2_request_info *req_info,
+                                     void *cmd_stats,
+                                     struct dnet_access_context *context);
 
 int dnet_read_json_header(int fd, uint64_t offset, uint64_t size, struct dnet_json_header *jhdr);
 

--- a/include/elliptics/interface.h
+++ b/include/elliptics/interface.h
@@ -55,6 +55,7 @@ struct dnet_net_state;
 struct dnet_config_data;
 struct dnet_node;
 struct dnet_session;
+struct n2_request_info;
 
 int dnet_need_exit(struct dnet_node *n);
 void dnet_set_need_exit(struct dnet_node *n);
@@ -306,6 +307,13 @@ struct dnet_backend_callbacks {
 	char *			(* dir)(void);
 
 	int			(* lookup)(struct dnet_node *n, void *priv, struct dnet_io_local *io);
+
+	/* command handler processes DNET_CMD_* commands protocol-undependently */
+	int			(* n2_command_handler)(void *state,
+	                                               void *priv,
+	                                               struct n2_request_info *req_info,
+	                                               void *cmd_stats,
+	                                               struct dnet_access_context *context);
 };
 
 /*
@@ -906,6 +914,11 @@ int dnet_send_reply_threshold(void *state, struct dnet_cmd *cmd,
 
 int dnet_send_fd_threshold(struct dnet_net_state *st, void *header, uint64_t hsize,
                            int fd, uint64_t offset, uint64_t dsize);
+
+int n2_send_error_response(struct dnet_net_state *st,
+                           struct n2_request_info *req_info,
+                           int errc,
+                           struct dnet_access_context *context);
 
 struct dnet_route_entry
 {

--- a/library/backend.cpp
+++ b/library/backend.cpp
@@ -1550,3 +1550,12 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
 	auto &callbacks = backend->callbacks();
 	return callbacks.command_handler(st, callbacks.command_private, cmd, data, cmd_stats, context);
 }
+
+int n2_backend_process_cmd_raw(struct dnet_backend *backend,
+                               struct dnet_net_state *st,
+                               struct n2_request_info *req_info,
+                               struct dnet_cmd_stats *cmd_stats,
+                               struct dnet_access_context *context) {
+	auto &callbacks = backend->callbacks();
+	return callbacks.n2_command_handler(st, callbacks.command_private, req_info, cmd_stats, context);
+}

--- a/library/backend.h
+++ b/library/backend.h
@@ -223,6 +223,12 @@ int dnet_backend_process_cmd_raw(struct dnet_backend *backend,
                                  struct dnet_cmd_stats *cmd_stats,
                                  struct dnet_access_context *context);
 
+int n2_backend_process_cmd_raw(struct dnet_backend *backend,
+                               struct dnet_net_state *st,
+                               struct n2_request_info *req_info,
+                               struct dnet_cmd_stats *cmd_stats,
+                               struct dnet_access_context *context);
+
 // handle command by @backend's cache
 int dnet_cmd_cache_io(struct dnet_backend *backend,
                       struct dnet_net_state *st,
@@ -230,6 +236,12 @@ int dnet_cmd_cache_io(struct dnet_backend *backend,
                       char *data,
                       struct dnet_cmd_stats *cmd_stats,
                       struct dnet_access_context *context);
+
+int n2_cmd_cache_io(struct dnet_backend *backend,
+                    struct dnet_net_state *st,
+                    struct n2_request_info *req_info,
+                    struct dnet_cmd_stats *cmd_stats,
+                    struct dnet_access_context *context);
 
 // initialize backends' subsystem, but do not enable any backend
 int dnet_backends_init(struct dnet_node *node);

--- a/library/n2_protocol.cpp
+++ b/library/n2_protocol.cpp
@@ -1,0 +1,139 @@
+#include "n2_protocol.h"
+#include "n2_protocol.hpp"
+
+#include <blackhole/attribute.hpp>
+#include <fcntl.h>
+
+#include "access_context.h"
+#include "common.hpp"
+#include "elliptics.h"
+#include "old_protocol/old_protocol.hpp"
+
+n2_message::n2_message(const dnet_cmd &cmd_)
+: cmd(cmd_)
+{}
+
+n2_request::n2_request(const dnet_cmd &cmd_, const dnet_time &deadline_)
+: n2_message(cmd_)
+, deadline(deadline_)
+{}
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+int protocol_interface::on_request(dnet_net_state *st, std::unique_ptr<n2_request_info> request_info) {
+	auto r = static_cast<dnet_io_req *>(calloc(1, sizeof(dnet_io_req)));
+	if (!r)
+		return -ENOMEM;
+
+	r->io_req_type = DNET_IO_REQ_TYPED_REQUEST;
+	r->request_info = request_info.release();
+
+	r->st = dnet_state_get(st);
+	dnet_schedule_io(st->n, r);
+
+	return 0;
+};
+
+protocol_interface *net_state_get_protocol(dnet_net_state* st) {
+	return &st->n->io->old_protocol->protocol;
+}
+
+static dnet_time default_deadline() {
+	dnet_time res;
+	dnet_empty_time(&res);
+	return res;
+}
+
+lookup_request::lookup_request(const dnet_cmd &cmd_)
+: n2_request(cmd_, default_deadline())
+{}
+
+lookup_response::lookup_response(const dnet_cmd &cmd_)
+: n2_message(cmd_)
+, record_flags(0)
+, user_flags(0)
+, path()
+, json_timestamp({0, 0})
+, json_offset(0)
+, json_size(0)
+, json_capacity(0)
+, json_checksum()
+, data_timestamp({0, 0})
+, data_offset(0)
+, data_size(0)
+, data_checksum()
+{}
+
+lookup_response::lookup_response(const dnet_cmd &cmd_,
+                                 uint64_t record_flags_,
+                                 uint64_t user_flags_,
+                                 std::string path_,
+                                 dnet_time json_timestamp_,
+                                 uint64_t json_offset_,
+                                 uint64_t json_size_,
+                                 uint64_t json_capacity_,
+                                 std::vector<unsigned char> json_checksum_,
+                                 dnet_time data_timestamp_,
+                                 uint64_t data_offset_,
+                                 uint64_t data_size_,
+                                 std::vector<unsigned char> data_checksum_)
+: n2_message(cmd_)
+, record_flags(record_flags_)
+, user_flags(user_flags_)
+, path(std::move(path_))
+, json_timestamp(json_timestamp_)
+, json_offset(json_offset_)
+, json_size(json_size_)
+, json_capacity(json_capacity_)
+, json_checksum(std::move(json_checksum_))
+, data_timestamp(data_timestamp_)
+, data_offset(data_offset_)
+, data_size(data_size_)
+, data_checksum(std::move(data_checksum_))
+{}
+
+}}} // namespace ioremap::elliptics::n2
+
+extern "C" {
+
+struct dnet_cmd *n2_io_req_get_cmd(struct dnet_io_req *r) {
+	switch (r->io_req_type) {
+	case DNET_IO_REQ_TYPED_REQUEST:
+		return &r->request_info->cmd;
+	case DNET_IO_REQ_TYPED_RESPONSE:
+		return &r->response_info->cmd;
+	default:
+		return nullptr; // Must never reach this code
+	}
+}
+
+dnet_cmd *n2_request_info_get_cmd(struct n2_request_info *req_info) {
+	return &req_info->request->cmd;
+}
+
+int n2_io_req_set_request_backend_id(struct dnet_io_req *r, int backend_id) {
+	if (r->io_req_type == DNET_IO_REQ_TYPED_REQUEST && r->request_info->request) {
+		// TODO: maybe to have shared_ptr on cmd and not to have two copies?
+		// Modify read-only long-lived cmd info
+		r->request_info->cmd.backend_id = backend_id;
+		// Modify cmd info within request
+		r->request_info->request->cmd.backend_id = backend_id;
+		return 0;
+	} else {
+		return -EINVAL;
+	}
+}
+
+void n2_request_info_free(struct n2_request_info *req_info) {
+	delete req_info;
+}
+
+void n2_response_info_free(struct n2_response_info *resp_info) {
+	delete resp_info;
+}
+
+void n2_trans_destroy_repliers(struct n2_repliers *repliers) {
+	delete repliers;
+}
+
+} // extern "C"

--- a/library/n2_protocol.h
+++ b/library/n2_protocol.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Helpers for integration with C
+
+struct dnet_cmd;
+struct dnet_io_req;
+struct n2_request_info;
+struct n2_response_info;
+
+struct dnet_cmd *n2_io_req_get_cmd(struct dnet_io_req *r);
+struct dnet_cmd *n2_request_info_get_cmd(struct n2_request_info *req_info);
+
+int n2_io_req_set_request_backend_id(struct dnet_io_req *r, int backend_id);
+
+void n2_request_info_free(struct n2_request_info *req_info);
+void n2_response_info_free(struct n2_response_info *resp_info);
+
+void n2_trans_destroy_repliers(struct n2_repliers *repliers);
+
+#ifdef __cplusplus
+}
+#endif

--- a/library/n2_protocol.hpp
+++ b/library/n2_protocol.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "elliptics/interface.h"
+#include "elliptics/utils.hpp"
+
+// Base class for requests and responses
+struct n2_message {
+	dnet_cmd cmd;
+	
+	explicit n2_message(const dnet_cmd &cmd);
+	virtual ~n2_message() = default;
+};
+
+// Base class for requests. Responses are inherited directly from n2_message.
+struct n2_request : n2_message {
+	dnet_time deadline;
+	
+	n2_request(const dnet_cmd &cmd, const dnet_time &deadline);
+};
+
+// Group of ways to reply on request. Some of replies can be unimplemented, depending on handler.
+// n2_repliers::on_reply_error is always implemented. Any replier returns error code. When client side
+// implements its replier, its error code is ignored.
+struct n2_repliers {
+	std::function<int (std::unique_ptr<n2_message>)> on_reply;
+	std::function<int (int)> on_reply_error;
+	// TODO: add streaming repliers
+};
+
+struct n2_request_info {
+	// Saved cmd copy. Reason: cmd info must be accessible beyond the lifetime of n2_request_info::request
+	// TODO(sabramkin): Don't hold cmd. If command handler needs to save some info from cmd, it must do it itself.
+	// TODO: or, maybe use here shared_ptr<dnet_cmd> cmd, which is carried by n2_request too
+	dnet_cmd cmd;
+
+	std::unique_ptr<n2_request> request;
+	n2_repliers repliers;
+};
+
+struct n2_response_info {
+	// Saved cmd copy (for logging, etc)
+	// TODO(sabramkin): Don't hold cmd. Use accessors for the required info.
+	// TODO: or, maybe use here shared_ptr<dnet_cmd> cmd, which is carried by response_holder too
+	dnet_cmd cmd;
+
+	std::function<int ()> response_holder;
+};
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+// Abstract interface of protocol
+class protocol_interface {
+public:
+	// Must be implemented on server side
+	static int __attribute__((weak)) on_request(dnet_net_state *st, std::unique_ptr<n2_request_info> request_info);
+
+	// Client side
+	virtual int send_request(dnet_net_state *st,
+	                         std::unique_ptr<n2_request> request,
+	                         n2_repliers repliers) = 0;
+
+	virtual ~protocol_interface() = default;
+};
+
+// Get connection's protocol
+protocol_interface *net_state_get_protocol(dnet_net_state* st);
+
+struct lookup_request : n2_request {
+	explicit lookup_request(const dnet_cmd &cmd);
+};
+
+struct lookup_response : n2_message {
+	uint64_t record_flags;
+	uint64_t user_flags;
+	std::string path;
+
+	dnet_time json_timestamp;
+	uint64_t json_offset;
+	uint64_t json_size;
+	uint64_t json_capacity;
+	std::vector<unsigned char> json_checksum;
+
+	dnet_time data_timestamp;
+	uint64_t data_offset;
+	uint64_t data_size;
+	std::vector<unsigned char> data_checksum;
+
+	// constructor used by deserializer, which fills the other fields manually
+	explicit lookup_response(const dnet_cmd &cmd);
+
+	// constructor used by handler
+	lookup_response(const dnet_cmd &cmd,
+	                uint64_t record_flags,
+	                uint64_t user_flags,
+	                std::string path,
+	                dnet_time json_timestamp,
+	                uint64_t json_offset,
+	                uint64_t json_size,
+	                uint64_t json_capacity,
+	                std::vector<unsigned char> json_checksum,
+	                dnet_time data_timestamp,
+	                uint64_t data_offset,
+	                uint64_t data_size,
+	                std::vector<unsigned char> data_checksum);
+};
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/deserialize.cpp
+++ b/library/old_protocol/deserialize.cpp
@@ -1,0 +1,100 @@
+#include "deserialize.hpp"
+
+#include <blackhole/attribute.hpp>
+#include <chrono>
+#include <msgpack.hpp>
+
+#include "library/common.hpp"
+#include "library/elliptics.h"
+
+namespace msgpack {
+
+using namespace ioremap::elliptics;
+
+inline dnet_time &operator >>(msgpack::object o, dnet_time &v) {
+	if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+		throw msgpack::type_error();
+	}
+
+	object *p = o.via.array.ptr;
+	p[0].convert(&v.tsec);
+	p[1].convert(&v.tnsec);
+	return v;
+}
+
+inline n2::lookup_response &operator >>(msgpack::object o, n2::lookup_response &v) {
+	if (o.type != msgpack::type::ARRAY || o.via.array.size < 10)
+		throw msgpack::type_error();
+
+	object *p = o.via.array.ptr;
+	p[0].convert(&v.record_flags);
+	p[1].convert(&v.user_flags);
+	p[2].convert(&v.path);
+
+	p[3].convert(&v.json_timestamp);
+	p[4].convert(&v.json_offset);
+	p[5].convert(&v.json_size);
+	p[6].convert(&v.json_capacity);
+
+	p[7].convert(&v.data_timestamp);
+	p[8].convert(&v.data_offset);
+	p[9].convert(&v.data_size);
+
+	if (o.via.array.size > 11) {
+		p[10].convert(&v.json_checksum);
+		p[11].convert(&v.data_checksum);
+
+		if ((!v.json_checksum.empty() && v.json_checksum.size() != DNET_CSUM_SIZE) ||
+		    (!v.data_checksum.empty() && v.data_checksum.size() != DNET_CSUM_SIZE)) {
+			throw std::runtime_error("Unexpected checksum size");
+		}
+	}
+
+	return v;
+}
+
+} // namespace msgpack
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+template<typename T>
+int unpack(dnet_net_state *st, const data_pointer &data, T &value, size_t &length_of_packed) {
+	try {
+		length_of_packed = 0;
+
+		msgpack::unpacked msg;
+		msgpack::unpack(&msg, data.data<char>(), data.size(), &length_of_packed);
+		msg.get().convert(&value);
+		return 0;
+
+	} catch (const std::exception &e) {
+		DNET_LOG_ERROR(st->n, "Failed to unpack msgpack message header: {}", e.what());
+		return -EINVAL;
+	}
+}
+
+int deserialize_lookup_request(dnet_net_state *st, const dnet_cmd &cmd,
+                               std::unique_ptr<n2_request> &out_deserialized) {
+	out_deserialized.reset(new(std::nothrow) lookup_request(cmd));
+	if (!out_deserialized)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int deserialize_lookup_response(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&message_buffer,
+                                std::unique_ptr<n2_message> &out_deserialized) {
+	std::unique_ptr<lookup_response> msg(new(std::nothrow) lookup_response(cmd));
+	if (!msg)
+		return -ENOMEM;
+
+	size_t unused_length_of_packed;
+	int err = unpack(st, message_buffer, *msg, unused_length_of_packed);
+	if (err)
+		return err;
+
+	out_deserialized = std::move(msg);
+	return 0;
+}
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/deserialize.hpp
+++ b/library/old_protocol/deserialize.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+#include "library/n2_protocol.hpp"
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+int deserialize_lookup_request(dnet_net_state *st, const dnet_cmd &cmd,
+                               std::unique_ptr<n2_request> &out_deserialized);
+int deserialize_lookup_response(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&message_buffer,
+                                std::unique_ptr<n2_message> &out_deserialized);
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/old_protocol.cpp
+++ b/library/old_protocol/old_protocol.cpp
@@ -1,0 +1,205 @@
+#include "old_protocol.hpp"
+
+#include <blackhole/attribute.hpp>
+
+#include "deserialize.hpp"
+#include "library/common.hpp"
+#include "library/elliptics.h"
+#include "library/logger.hpp"
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+int old_protocol::send_request(dnet_net_state *st,
+                               std::unique_ptr<n2_request> request,
+                               n2_repliers repliers) {
+	auto &cmd = request->cmd;
+
+	{
+		// Note: currently transaction is created outside from protocol. When we'll create it in protocol,
+		// we shouldn't search it here
+
+		pthread_mutex_lock(&st->trans_lock);
+		std::unique_ptr<pthread_mutex_t, int (*)(pthread_mutex_t *)>
+			trans_guard(&st->trans_lock, &pthread_mutex_unlock);
+		std::unique_ptr<dnet_trans, void (*)(dnet_trans *)>
+			t(dnet_trans_search(st, cmd.trans), &dnet_trans_put);
+
+		if (!t || !t->repliers)
+			return -EINVAL;
+
+		*t->repliers = std::move(repliers);
+	}
+
+	switch (cmd.cmd) {
+	case DNET_CMD_LOOKUP_NEW:
+		{
+			std::unique_ptr<n2_serialized> serialized;
+			int err = serialize_lookup_request(st, std::move(request), serialized);
+			if (err)
+				return err;
+
+			return enqueue_net(st, std::move(serialized));
+		}
+	default:
+		return -EINVAL;
+	}
+}
+
+int old_protocol::recv_message(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body) {
+	if (cmd.flags & DNET_FLAGS_REPLY) {
+		return recv_response(st, cmd, std::move(body));
+	} else {
+		return recv_request(st, cmd, std::move(body));
+	}
+}
+
+int old_protocol::recv_request(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body) {
+	switch (cmd.cmd) {
+	case DNET_CMD_LOOKUP_NEW:
+		return translate_lookup_request(st, cmd);
+	default:
+		// Must never reach this code, due to is_supported_message() filter called before
+		return -ENOTSUP;
+	}
+}
+
+int old_protocol::recv_response(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body) {
+
+	pthread_mutex_lock(&st->trans_lock);
+	std::unique_ptr<dnet_trans, void (*)(dnet_trans *)>
+		t(dnet_trans_search(st, cmd.trans), &dnet_trans_put);
+	pthread_mutex_unlock(&st->trans_lock);
+
+	if (!t || !t->repliers)
+		return -EINVAL;
+
+	n2_repliers &repliers = *t->repliers;
+
+	if (cmd.status) {
+		return repliers.on_reply_error(cmd.status);
+
+	} else {
+		switch (cmd.cmd) {
+		case DNET_CMD_LOOKUP_NEW:
+			{
+				std::unique_ptr<n2_message> msg;
+				int err = deserialize_lookup_response(st, cmd, std::move(body), msg);
+				if (err)
+					return err;
+
+				return repliers.on_reply(std::move(msg));
+			}
+		default:
+			// Must never reach this code, due to is_supported_message() filter called before
+			return -ENOTSUP;
+		}
+	}
+}
+
+int old_protocol::schedule_request_info(dnet_net_state *st,
+                                        std::unique_ptr<n2_request_info> &&request_info) {
+	request_info->cmd = request_info->request->cmd;
+	return on_request(st, std::move(request_info));
+}
+
+int old_protocol::translate_lookup_request(dnet_net_state *st, const dnet_cmd &cmd) {
+	std::unique_ptr<n2_request_info> request_info(new(std::nothrow) n2_request_info);
+	if (!request_info)
+		return -ENOMEM;
+
+	int err = deserialize_lookup_request(st, cmd, request_info->request);
+	if (err)
+		return err;
+
+	auto replier = std::make_shared<lookup_replier>(st, request_info->request->cmd);
+	request_info->repliers.on_reply = std::bind(&lookup_replier::reply, replier, std::placeholders::_1);
+	request_info->repliers.on_reply_error = std::bind(&lookup_replier::reply_error, replier, std::placeholders::_1);
+
+	return schedule_request_info(st, std::move(request_info));
+}
+
+}}} // namespace ioremap::elliptics::n2
+
+extern "C" {
+
+int n2_old_protocol_io_start(struct dnet_node *n) {
+	auto impl = [io = n->io] {
+		io->old_protocol = new(std::nothrow) n2_old_protocol_io;
+		if (!io->old_protocol)
+			return -ENOMEM;
+
+		return 0;
+	};
+	return c_exception_guard(impl, n, __FUNCTION__);
+}
+
+void n2_old_protocol_io_stop(struct dnet_node *n) {
+	auto impl = [io = n->io] {
+		delete io->old_protocol;
+		io->old_protocol = nullptr;
+		return 0;
+	};
+	c_exception_guard(impl, n, __FUNCTION__);
+}
+
+int n2_old_protocol_rcvbuf_create(struct dnet_net_state *st) {
+	st->rcv_buffer = new(std::nothrow) n2_recv_buffer;
+	if (!st->rcv_buffer)
+		return -ENOMEM;
+
+	return 0;
+}
+
+void n2_old_protocol_rcvbuf_destroy(struct dnet_net_state *st) {
+	delete st->rcv_buffer;
+	st->rcv_buffer = nullptr;
+}
+
+bool n2_old_protocol_is_supported_message(struct dnet_net_state *st) {
+	const dnet_cmd *cmd = &st->rcv_cmd;
+
+	// Replies addressed to client are currently passed via old mechanic. This condition branch will be removed
+	// after client supports new mechanic for DNET_CMD_LOOKUP_NEW command.
+	if (cmd->flags & DNET_FLAGS_REPLY) {
+		std::unique_ptr<dnet_trans, void (*)(dnet_trans *)>
+		        t(dnet_trans_search(st, cmd->trans), &dnet_trans_put);
+
+		if (t && !t->repliers)
+			return false;
+	}
+
+	return cmd->cmd == DNET_CMD_LOOKUP_NEW;
+}
+
+int n2_old_protocol_prepare_message_buffer(struct dnet_net_state *st) {
+	if (!n2_old_protocol_is_supported_message(st)) {
+		st->rcv_buffer_used = 0;
+		return -ENOTSUP;
+	} else {
+		st->rcv_buffer_used = 1;
+	}
+
+	const dnet_cmd *cmd = &st->rcv_cmd;
+
+	st->rcv_buffer->buf = ioremap::elliptics::data_pointer::allocate(cmd->size);
+	st->rcv_data = st->rcv_buffer->buf.data();
+	st->rcv_offset = 0;
+	st->rcv_end = cmd->size;
+	return 0;
+}
+
+int n2_old_protocol_schedule_message(struct dnet_net_state *st) {
+	if (!st->rcv_buffer_used)
+		return -ENOTSUP;
+
+	auto impl = [&] {
+		return st->n->io->old_protocol->protocol.recv_message(st, st->rcv_cmd, std::move(st->rcv_buffer->buf));
+	};
+	return c_exception_guard(impl, st->n, __FUNCTION__);
+}
+
+void n2_serialized_free(struct n2_serialized *serialized) {
+	delete serialized;
+}
+
+} // extern "С"

--- a/library/old_protocol/old_protocol.h
+++ b/library/old_protocol/old_protocol.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dnet_cmd;
+struct dnet_net_state;
+struct dnet_node;
+
+int n2_old_protocol_io_start(struct dnet_node *n);
+void n2_old_protocol_io_stop(struct dnet_node *n);
+
+int n2_old_protocol_rcvbuf_create(struct dnet_net_state *st);
+void n2_old_protocol_rcvbuf_destroy(struct dnet_net_state *st);
+int n2_old_protocol_prepare_message_buffer(struct dnet_net_state *st);
+int n2_old_protocol_schedule_message(struct dnet_net_state *st);
+
+void n2_serialized_free(struct n2_serialized *serialized);
+
+#ifdef __cplusplus
+}
+#endif

--- a/library/old_protocol/old_protocol.hpp
+++ b/library/old_protocol/old_protocol.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "library/n2_protocol.hpp"
+#include "repliers.hpp"
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+class old_protocol : public protocol_interface {
+public:
+	// Client side
+	int send_request(dnet_net_state *st,
+	                 std::unique_ptr<n2_request> request,
+	                 n2_repliers repliers) override;
+
+	// Net side
+	int recv_message(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body);
+
+private:
+	int recv_request(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body);
+	int recv_response(dnet_net_state *st, const dnet_cmd &cmd, data_pointer &&body);
+
+	int schedule_request_info(dnet_net_state *st, std::unique_ptr<n2_request_info> &&request_info);
+	int translate_lookup_request(dnet_net_state *st, const dnet_cmd &cmd);
+};
+
+}}} // namespace ioremap::elliptics::n2
+
+extern "C" {
+
+struct n2_old_protocol_io {
+	ioremap::elliptics::n2::old_protocol protocol;
+};
+
+struct n2_recv_buffer {
+	ioremap::elliptics::data_pointer buf;
+};
+
+} // extern "C"

--- a/library/old_protocol/repliers.cpp
+++ b/library/old_protocol/repliers.cpp
@@ -1,0 +1,74 @@
+#include "repliers.hpp"
+
+#include <blackhole/attribute.hpp>
+#include <msgpack.hpp>
+
+#include "deserialize.hpp"
+#include "library/common.hpp"
+#include "library/elliptics.h"
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+replier_base::replier_base(const char *handler_name, dnet_net_state *st, const dnet_cmd &cmd)
+: st_(st)
+, handler_name_(handler_name)
+, reply_has_sent_(ATOMIC_FLAG_INIT)
+, cmd_(cmd)
+{}
+
+int replier_base::reply(std::unique_ptr<n2_message> msg) {
+	auto impl = [&] {
+		msg->cmd.trans = cmd_.trans;
+		return reply_impl(std::move(msg));
+	};
+
+	if (!reply_has_sent_.test_and_set()) {
+		return c_exception_guard(impl, st_->n, __FUNCTION__);
+	} else {
+		return -EALREADY;
+	}
+}
+
+int replier_base::reply_error(int errc) {
+	if (!reply_has_sent_.test_and_set()) {
+		return c_exception_guard(std::bind(&replier_base::reply_error_impl, this, errc),
+		                         st_->n, __FUNCTION__);
+	} else {
+		return -EALREADY;
+	}
+}
+
+int replier_base::reply_impl(std::unique_ptr<n2_message> msg) {
+	return -EINVAL;
+}
+
+int replier_base::reply_error_impl(int errc) {
+	if (!(cmd_.flags & DNET_FLAGS_NEED_ACK))
+		return 0;
+
+	dnet_cmd cmd = cmd_;
+	cmd.size = 0;
+	cmd.status = errc;
+
+	std::unique_ptr<n2_serialized> serialized;
+	int err = serialize_error_response(st_, cmd, serialized);
+	if (err)
+		return err;
+
+	return enqueue_net(st_, std::move(serialized));
+}
+
+lookup_replier::lookup_replier(dnet_net_state *st, const dnet_cmd &cmd)
+: replier_base("LOOKUP_NEW", st, cmd)
+{}
+
+int lookup_replier::reply_impl(std::unique_ptr<n2_message> msg) {
+	std::unique_ptr<n2_serialized> serialized;
+	int err = serialize_lookup_response(st_, std::move(msg), serialized);
+	if (err)
+		return err;
+
+	return enqueue_net(st_, std::move(serialized));
+}
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/repliers.hpp
+++ b/library/old_protocol/repliers.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+
+#include "library/n2_protocol.hpp"
+#include "serialize.hpp"
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+/*
+ * Here are grouped the implementations of n2_repliers that are called from message handler as a result of message
+ * processing. For each message type, calls of n2_repliers::on_reply* callbacks are dependent on each other. For
+ * example, for simple scalar requests (e.g. lookup by key) only one of callbacks (on_reply or on_reply_error) must to
+ * be called, and if any extra (unexpected) call occur, would be better to resolve this situation some way to not to
+ * produce the harm. At least, any unexpected on_reply* call mustn't be passed to any underlying systems, and definitely
+ * mustn't to be sent by net. For more complex logic of replying, the callbacks dependence is also more complex. To
+ * serve this, n2_repliers are implemented via the instance of class that looks after the order of callback calls.
+ */
+
+class replier_base {
+public:
+	replier_base(const char *handler_name, dnet_net_state *st, const dnet_cmd &cmd);
+	int reply(std::unique_ptr<n2_message> msg);
+	int reply_error(int errc);
+
+protected:
+	dnet_net_state *st_;
+
+private:
+	virtual int reply_impl(std::unique_ptr<n2_message> msg);
+	int reply_error_impl(int errc);
+
+	const char *handler_name_;
+	std::atomic_flag reply_has_sent_;
+
+	dnet_cmd cmd_;
+};
+
+// Lookup request stuff
+
+class lookup_replier : public replier_base {
+public:
+	lookup_replier(dnet_net_state *st, const dnet_cmd &cmd);
+
+private:
+	int reply_impl(std::unique_ptr<n2_message> msg) override;
+};
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/serialize.cpp
+++ b/library/old_protocol/serialize.cpp
@@ -1,0 +1,109 @@
+#include "serialize.hpp"
+
+#include <blackhole/attribute.hpp>
+#include <msgpack.hpp>
+
+#include "library/common.hpp"
+#include "library/elliptics.h"
+
+namespace msgpack {
+
+using namespace ioremap::elliptics;
+
+template <typename Stream>
+inline msgpack::packer<Stream> &operator <<(msgpack::packer<Stream> &o, const dnet_time &v) {
+	o.pack_array(2);
+	o.pack_fix_uint64(v.tsec);
+	o.pack_fix_uint64(v.tnsec);
+	return o;
+}
+
+template <typename Stream>
+inline msgpack::packer<Stream> &operator<<(msgpack::packer<Stream> &o, const n2::lookup_response &v) {
+	o.pack_array(12);
+
+	o.pack(v.record_flags);
+	o.pack(v.user_flags);
+	o.pack(v.path);
+
+	o.pack(v.json_timestamp);
+	o.pack(v.json_offset);
+	o.pack(v.json_size);
+	o.pack(v.json_capacity);
+
+	o.pack(v.data_timestamp);
+	o.pack(v.data_offset);
+	o.pack(v.data_size);
+
+	o.pack(v.json_checksum);
+	o.pack(v.data_checksum);
+
+	return o;
+}
+
+} // namespace msgpack
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+int enqueue_net(dnet_net_state *st, std::unique_ptr<n2_serialized> serialized) {
+	auto r = static_cast<dnet_io_req *>(calloc(1, sizeof(dnet_io_req)));
+	if (!r)
+		return -ENOMEM;
+
+	r->serialized = serialized.release();
+	dnet_io_req_enqueue_net(st, r);
+	return 0;
+}
+
+static uint64_t response_transform_flags(uint64_t flags) {
+	return (flags & ~(DNET_FLAGS_NEED_ACK)) | DNET_FLAGS_REPLY;
+}
+
+int serialize_error_response(dnet_net_state *st, const dnet_cmd &cmd_in,
+                             std::unique_ptr<n2_serialized> &out_serialized) {
+	dnet_cmd cmd = cmd_in;
+	cmd.flags = response_transform_flags(cmd.flags);
+
+	out_serialized.reset(new(std::nothrow) n2_serialized{ cmd, {} });
+	if (!out_serialized)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int serialize_lookup_request(dnet_net_state *st, std::unique_ptr<n2_request> msg_in,
+                             std::unique_ptr<n2_serialized> &out_serialized) {
+	auto &msg = static_cast<lookup_request &>(*msg_in);
+
+	out_serialized.reset(new(std::nothrow) n2_serialized{ msg.cmd, {} });
+	if (!out_serialized)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int serialize_lookup_response(dnet_net_state *st, std::unique_ptr<n2_message> msg_in,
+                              std::unique_ptr<n2_serialized> &out_serialized) {
+	auto impl = [&] {
+		auto &msg = static_cast<lookup_response &>(*msg_in);
+
+		msgpack::sbuffer msgpack_buffer;
+		msgpack::pack(msgpack_buffer, msg);
+
+		dnet_cmd cmd = msg.cmd;
+		cmd.flags = response_transform_flags(cmd.flags);
+		cmd.size = msgpack_buffer.size();
+
+		out_serialized.reset(new(std::nothrow) n2_serialized{
+			cmd, { data_pointer::copy(msgpack_buffer.data(), msgpack_buffer.size()) }
+		});
+		if (!out_serialized)
+			return -ENOMEM;
+
+		return 0;
+	};
+
+	return c_exception_guard(impl, st->n, __FUNCTION__);
+}
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/old_protocol/serialize.hpp
+++ b/library/old_protocol/serialize.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <atomic>
+
+#include "library/n2_protocol.hpp"
+
+struct n2_serialized {
+	dnet_cmd cmd;
+
+	// Typed message usually represented as some struct that references to allocated memory blocks. When we serialize,
+	// we don't want to concat large blocks of data to one continuous memory block, since we don't want to copy memory.
+	// Instead, we get serialized message as multi-chunk vector, each chunk ot that is a view of particular message part.
+	// TODO: Assumed that sendfile'll be supported later, and n2_serialized became vector<some_variant>
+	std::vector<ioremap::elliptics::data_pointer> chunks;
+};
+
+namespace ioremap { namespace elliptics { namespace n2 {
+
+int enqueue_net(dnet_net_state *st, std::unique_ptr<n2_serialized> serialized);
+
+// Serializators for requests and responses
+
+int serialize_error_response(dnet_net_state *st, const dnet_cmd &cmd_in,
+                             std::unique_ptr<n2_serialized> &out_serialized);
+
+int serialize_lookup_request(dnet_net_state *st, std::unique_ptr<n2_request> msg_in,
+                             std::unique_ptr<n2_serialized> &out_serialized);
+int serialize_lookup_response(dnet_net_state *st, std::unique_ptr<n2_message> msg_in,
+                              std::unique_ptr<n2_serialized> &out_serialized);
+
+}}} // namespace ioremap::elliptics::n2

--- a/library/pool.c
+++ b/library/pool.c
@@ -38,6 +38,8 @@
 #include "request_queue.h"
 #include "library/logger.hpp"
 #include "library/backend.h"
+#include "library/n2_protocol.h"
+#include "library/old_protocol/old_protocol.h"
 
 static char *dnet_work_io_mode_string[] = {
 	[DNET_WORK_IO_MODE_BLOCKING] = "BLOCKING",
@@ -276,10 +278,31 @@ static inline void make_thread_stat_id(char *buffer, int size, struct dnet_work_
 	snprintf(buffer, size - 1, "%s.%s", pool->pool_id, mode_marker);
 }
 
+struct dnet_cmd *dnet_io_req_get_cmd(struct dnet_io_req *r) {
+	if (r->io_req_type == DNET_IO_REQ_OLD_PROTOCOL)
+		// dnet_io_req enqueued from old mechanic
+		return r->header;
+	else
+		// dnet_io_req enqueued from protocol-independent mechanic
+		return n2_io_req_get_cmd(r);
+}
+
+int dnet_io_req_set_request_backend_id(struct dnet_io_req *r, int backend_id) {
+	if (r->io_req_type == DNET_IO_REQ_OLD_PROTOCOL) {
+		// dnet_io_req enqueued from old mechanic
+		struct dnet_cmd *cmd = r->header;
+		cmd->backend_id = backend_id;
+		return 0;
+	} else {
+		// dnet_io_req enqueued from protocol-independent mechanic
+		return n2_io_req_set_request_backend_id(r, backend_id);
+	}
+}
+
 static void dnet_update_trans_timestamp_network(struct dnet_io_req *r)
 {
 	struct dnet_net_state *st = r->st;
-	struct dnet_cmd *cmd = r->header;
+	struct dnet_cmd *cmd = dnet_io_req_get_cmd(r);
 
 	if (cmd->flags & DNET_FLAGS_REPLY) {
 		struct dnet_trans *t;
@@ -306,7 +329,7 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 {
 	struct dnet_work_pool_place *place = NULL;
 	struct dnet_work_pool *pool = NULL;
-	struct dnet_cmd *cmd = r->header;
+	struct dnet_cmd *cmd = dnet_io_req_get_cmd(r);
 	int nonblocking = !!(cmd->flags & DNET_FLAGS_NOLOCK);
 	ssize_t backend_id = -1;
 	char thread_stat_id[255];
@@ -352,11 +375,20 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 
 	// If we are processing the command we should update cmd->backend_id to actual one
 	if (!(cmd->flags & DNET_FLAGS_REPLY)) {
-		cmd->backend_id = backend_id >= 0 ? backend_id : -1;
+		int err = dnet_io_req_set_request_backend_id(r, backend_id >= 0 ? backend_id : -1);
+
+		// TODO(sabramkin): error can occur only during unfinished refactoring, remove this error case
+		if (err) {
+			dnet_log(n, DNET_LOG_ERROR, "%s: %s: backend_id: %zd, place: %p, "
+			                            "failed to set cmd->backend_id : %s %d",
+	        	         dnet_state_dump_addr(r->st), dnet_dump_id(&cmd->id), backend_id, place,
+	        	         strerror(-err), err);
+			return;
+		}
 	}
 
 	dnet_log(n, DNET_LOG_DEBUG, "%s: %s: backend_id: %zd, place: %p, cmd->backend_id: %d",
-	         dnet_state_dump_addr(r->st), dnet_dump_id(r->header), backend_id, place, cmd->backend_id);
+	         dnet_state_dump_addr(r->st), dnet_dump_id(&cmd->id), backend_id, place, cmd->backend_id);
 
 	dnet_push_request(pool, r, thread_stat_id);
 
@@ -366,7 +398,6 @@ void dnet_schedule_io(struct dnet_node *n, struct dnet_io_req *r)
 	FORMATTED(HANDY_COUNTER_INCREMENT, ("pool.%s.queue.size", thread_stat_id), 1);
 	HANDY_COUNTER_INCREMENT("io.input.queue.size", 1);
 }
-
 
 void dnet_schedule_command(struct dnet_net_state *st)
 {
@@ -379,7 +410,8 @@ void dnet_schedule_command(struct dnet_net_state *st)
 		dnet_log(st->n, DNET_LOG_DEBUG, "freed: size: %llu, trans: %llu, reply: %d, ptr: %p.",
 						(unsigned long long)c->size, tid, tid != c->trans, st->rcv_data);
 #endif
-		free(st->rcv_data);
+		if (!st->rcv_buffer_used)
+			free(st->rcv_data);
 		st->rcv_data = NULL;
 	}
 
@@ -455,6 +487,18 @@ again:
 				dnet_state_dump_addr(st), c->backend_id,
 				(unsigned long long)c->size, dnet_flags_dump_cflags(c->flags), c->status);
 
+		st->rcv_flags &= ~DNET_IO_CMD;
+
+		err = n2_old_protocol_prepare_message_buffer(st);
+		if (err == 0) {
+			if (c->size)
+				goto again;
+			else
+				goto schedule;
+		}
+		if (err != -ENOTSUP)
+			goto out;
+
 		r = malloc(c->size + sizeof(struct dnet_cmd) + sizeof(struct dnet_io_req));
 		if (!r) {
 			err = -ENOMEM;
@@ -469,7 +513,6 @@ again:
 		st->rcv_data = r;
 		st->rcv_offset = sizeof(struct dnet_io_req) + sizeof(struct dnet_cmd);
 		st->rcv_end = st->rcv_offset + c->size;
-		st->rcv_flags &= ~DNET_IO_CMD;
 
 		if (c->size) {
 			r->data = r->header + sizeof(struct dnet_cmd);
@@ -482,9 +525,15 @@ again:
 		}
 	}
 
+schedule:
+	clock_gettime(CLOCK_MONOTONIC_RAW, &st->rcv_finish_ts);
+
+	err = n2_old_protocol_schedule_message(st);
+	if (err != -ENOTSUP)
+		goto out;
+
 	r = st->rcv_data;
 	st->rcv_data = NULL;
-	clock_gettime(CLOCK_MONOTONIC_RAW, &st->rcv_finish_ts);
 
 	dnet_schedule_command(st);
 
@@ -669,8 +718,9 @@ static int dnet_process_send_single(struct dnet_net_state *st)
 			goto err_out_exit;
 		}
 
-		err = dnet_send_request(st, r);
-		if (st->send_offset == (r->dsize + r->hsize + r->fsize)) {
+		err = r->serialized ? n2_send_request(st, r) : dnet_send_request(st, r);
+
+		if (!err) {
 			pthread_mutex_lock(&st->send_lock);
 			list_del(&r->req_entry);
 			pthread_mutex_unlock(&st->send_lock);
@@ -1041,20 +1091,20 @@ void *dnet_io_process(void *data_) {
 		FORMATTED(HANDY_COUNTER_INCREMENT, ("pool.%s.active_threads", thread_stat_id), 1);
 
 		st = r->st;
-		cmd = r->header;
+		cmd = dnet_io_req_get_cmd(r);
 
 		dnet_logger_set_backend_id(cmd->backend_id);
 		dnet_logger_set_trace_id(cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT);
 
 		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: got IO event: %p: cmd: %s, hsize: %zu, dsize: %zu, mode: %s, "
 		                            "backend_id: %d, queue_time: %lu usecs",
-		         dnet_state_dump_addr(st), dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd), r->hsize,
+		         dnet_state_dump_addr(st), dnet_dump_id(&cmd->id), r, dnet_cmd_string(cmd->cmd), r->hsize,
 		         r->dsize, dnet_work_io_mode_str(pool->mode), cmd->backend_id, r->queue_time);
 
 		dnet_process_recv(st, r);
 
 		dnet_log(n, DNET_LOG_DEBUG, "%s: %s: processed IO event: %p, cmd: %s", dnet_state_dump_addr(st),
-		         dnet_dump_id(r->header), r, dnet_cmd_string(cmd->cmd));
+		         dnet_dump_id(&cmd->id), r, dnet_cmd_string(cmd->cmd));
 
 		dnet_release_request(wio, r);
 		dnet_io_req_free(r);
@@ -1126,6 +1176,11 @@ int dnet_io_init(struct dnet_node *n, struct dnet_config *cfg)
 		goto err_out_cleanup_recv_place_nb;
 	}
 
+	err = n2_old_protocol_io_start(n);
+	if (err) {
+		goto err_out_free_recv_pool_nb;
+	}
+
 	for (i=0; i<n->io->net_thread_num; ++i) {
 		struct dnet_net_io *nio = &n->io->net[i];
 
@@ -1159,6 +1214,8 @@ err_out_net_destroy:
 		close(n->io->net[i].epoll_fd);
 	}
 
+err_out_free_recv_pool_nb:
+	n->need_exit = 1;
 	dnet_work_pool_exit(&n->io->pool.recv_pool_nb);
 err_out_cleanup_recv_place_nb:
 	dnet_work_pool_place_cleanup(&n->io->pool.recv_pool_nb);
@@ -1188,6 +1245,8 @@ void dnet_io_stop(struct dnet_node *n) {
 		pthread_join(io->net[i].tid, NULL);
 		close(io->net[i].epoll_fd);
 	}
+
+	n2_old_protocol_io_stop(n);
 
 	dnet_work_pool_stop(&io->pool.recv_pool_nb);
 	dnet_work_pool_stop(&io->pool.recv_pool);

--- a/library/trans.c
+++ b/library/trans.c
@@ -30,6 +30,7 @@
 #include "elliptics/packet.h"
 #include "elliptics/interface.h"
 #include "library/logger.hpp"
+#include "library/n2_protocol.h"
 
 #define CHECK_THREAD_WAKEUP_PERIOD_NS (10 * 1000 * 1000)
 
@@ -264,6 +265,10 @@ void dnet_trans_destroy(struct dnet_trans *t)
 	if (t->complete) {
 		t->cmd.flags |= DNET_FLAGS_DESTROY;
 		t->complete(t->st ? dnet_state_addr(t->st) : NULL, &t->cmd, t->priv);
+	}
+
+	if (t->repliers) {
+		n2_trans_destroy_repliers(t->repliers);
 	}
 
 	if (st && st->n && t->command) {


### PR DESCRIPTION
* Only lookup_new
* Except elliptics-client

Background information:
* Struct `dnet_cmd`: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/include/elliptics/packet.h#L282
* Struct `dnet_io_req`: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/elliptics.h#L62

Old behavior, with remarks:
* (1) Message's raw bytes are received here: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/pool.c#L390
* (2) When full message collected, it's enqueued to io_pool as `dnet_io_req`: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/pool.c#L493
* (3) Message is dequeued here: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/net.c#L698
* (4) Message (request) is deserialized in handler: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/example/eblob_backend.cpp#L755 (this line - only header deserialization, other data is accessed raw).
* (5) Response is also serialized in handler: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/example/eblob_backend.cpp#L678 (at the line we see blob allocation, next lines - blob filling).
* (6) Then, from handler, response can be sent by `dnet_send_*` functions family (here response is sent by `dnet_send_fd` func): https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/example/eblob_backend.cpp#L689
* (7) Link to `dnet_send_fd` internals (create `dnet_io_req` and enqueue it to net or to inner state queue): https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/net.c#L437
* (8) Enqueueing details: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/net.c#L288
* (9) If we enqueue to local state, we next go to (3). If we send by net, we unwind send_list here: https://github.com/interiorem/elliptics/blob/258c109ab6b85dcb074d7d4dd71d069b91ffb2fa/library/pool.c#L672 and send to socket.

New behavior:

Briefly, io_pool (request queue) must contain requests/responses, and mustn't know about net protocol details. So, in PR:
* At step (2), *typed message* (gotten from protocol) is enqueued to io_pool as `dnet_io_req`.
* At step (5), in handler we reply by *typed message*, that is enqueued to local state, or passed to protocol.

New behavior details:

* Protocol abstract interface: https://github.com/sabramkin/elliptics/blob/7f57d195c0d4f359b9bc91c606ae6063d442f74b/library/n2_protocol.hpp#L50
* Each request is provided as `n2_request_info` (request with repliers): https://github.com/sabramkin/elliptics/blob/7f57d195c0d4f359b9bc91c606ae6063d442f74b/library/n2_protocol.hpp#L34
* How handler works with `n2_request_info`: https://github.com/sabramkin/elliptics/blob/7f57d195c0d4f359b9bc91c606ae6063d442f74b/example/eblob_backend.cpp#L219
* Repliers are implemented in protocol: https://github.com/sabramkin/elliptics/blob/7f57d195c0d4f359b9bc91c606ae6063d442f74b/library/old_protocol/translate_request.cpp#L74
* Fork of old/new mechanic on receive from net: https://github.com/sabramkin/elliptics/blob/a3836950a3ce50ade0f1907828c535ded929ca30/library/pool.c#L479
* Сoupling of old/new mechanic on send to net: https://github.com/sabramkin/elliptics/blob/a3836950a3ce50ade0f1907828c535ded929ca30/library/pool.c#L700
* Changes in `dnet_io_req` to support new mechanic: https://github.com/sabramkin/elliptics/blob/a3836950a3ce50ade0f1907828c535ded929ca30/library/elliptics.h#L95

I recommend to view PR in such order:
1. `library/n2_protocol.hpp`
2. `example/eblob_backend.cpp` and `cache/cache.cpp`
3. `library/old_protocol/`
4. Other changes.
